### PR TITLE
Add rg adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ SublimeText, Atom et al.
 [ag](https://github.com/ggreer/the_silver_searcher#installing) (_The Silver Searcher_),
 [ack](http://beyondgrep.com/install/),
 [pt](https://github.com/monochromegane/the_platinum_searcher#installation) (_The Platinum Searcher_),
+[rg](https://github.com/BurntSushi/ripgrep#installation) (_ripgrep_),
 [git-grep](https://git-scm.com/docs/git-grep) along with the
 native \*nix util [grep](http://linux.die.net/man/1/grep).
 * Advanced pattern input prompt with fuzzy- and spell suggestion-driven completion.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ let g:esearch = {
 
 * __'adapter'__<br>
   Adapter is a system-wide executable, which is used to dispatch your search
-  request. Currently available adapters are `'ag'`, `'ack'`, `'pt'`, `'git'` and `'grep'`.
+  request. Currently available adapters are `'ag'`, `'ack'`, `'pt'`, 'rg', `'git'` and `'grep'`.
 * __'backend'__<br>
   Backend is a strategy, which is used to collaborate with an adapter. Currently available:
   async backends - `'nvim'`, `'vimproc'`, and vim builtin system() func call based backend

--- a/autoload/esearch/adapter/rg.vim
+++ b/autoload/esearch/adapter/rg.vim
@@ -1,0 +1,40 @@
+" TODO reduce duplication with #ag
+
+fu! esearch#adapter#rg#options() abort
+  if !exists('s:options')
+    let s:options = {
+    \ 'regex':   { 'p': ['--fixed-strings', ''], 's': ['>', 'r'] },
+    \ 'case':    { 'p': ['--ignore-case', ''],   's': ['>', 'c'] },
+    \ 'word':    { 'p': ['',   '--word-regexp'],  's': ['>', 'w'] },
+    \ 'stringify':   function('esearch#util#stringify'),
+    \ 'parametrize': function('esearch#util#parametrize'),
+    \}
+  endif
+  return s:options
+endfu
+
+fu! esearch#adapter#rg#cmd(pattern, dir, escape, ...) abort
+  let options = a:0 ? a:1 : esearch#adapter#rg#options()
+  let r = options.parametrize('regex')
+  let c = options.parametrize('case')
+  let w = options.parametrize('word')
+  return 'rg '.r.' '.c.' '.w.' --no-heading --color=never --column -- ' .
+        \ a:escape(a:pattern)  . ' ' . fnameescape(a:dir)
+endfu
+
+fu! esearch#adapter#rg#is_broken_result(...) abort
+  return call('esearch#adapter#ag#is_broken_result')
+endfu
+
+fu! esearch#adapter#rg#parse_results(...) abort
+  return call('esearch#adapter#ag#parse_results', a:000)
+endfu
+
+fu! esearch#adapter#rg#requires_pty() abort
+  return 1
+endfu
+
+function! esearch#adapter#rg#sid() abort
+  return maparg('<SID>', 'n')
+endfunction
+nnoremap <SID>  <SID>

--- a/autoload/esearch/opts.vim
+++ b/autoload/esearch/opts.vim
@@ -13,12 +13,12 @@ fu! esearch#opts#new(opts) abort
   endif
 
   if !has_key(opts, 'adapter')
-    if executable('rg')
-      let opts.adapter = 'rg'
-    elseif executable('ag')
+    if executable('ag')
       let opts.adapter = 'ag'
     elseif executable('pt')
       let opts.adapter = 'pt'
+    elseif executable('rg')
+      let opts.adapter = 'rg'
     elseif executable('ack')
       let opts.adapter = 'ack'
     elseif !system('git rev-parse --is-inside-work-tree &>/dev/null') && !v:shell_error

--- a/autoload/esearch/opts.vim
+++ b/autoload/esearch/opts.vim
@@ -13,7 +13,9 @@ fu! esearch#opts#new(opts) abort
   endif
 
   if !has_key(opts, 'adapter')
-    if executable('ag')
+    if executable('rg')
+      let opts.adapter = 'rg'
+    elseif executable('ag')
       let opts.adapter = 'ag'
     elseif executable('pt')
       let opts.adapter = 'pt'

--- a/doc/vim_esearch.txt
+++ b/doc/vim_esearch.txt
@@ -59,7 +59,7 @@ Note: don't set values if you don't need to override default behaviour.
 
                                         *Esearch-adapter*
 Adapter is a system-wide executable, which is used to dispatch your search
-request. Currently available adapters are 'ag', 'ack', 'pt', 'git' and 'grep'.
+request. Currently available adapters are 'ag', 'ack', 'pt', 'rg', 'git' and 'grep'.
 To set this option use |g:esearch|.
 
 Example:

--- a/spec/plugin/shared_examples/backend.rb
+++ b/spec/plugin/shared_examples/backend.rb
@@ -1,5 +1,5 @@
 RSpec.shared_examples 'a backend' do |backend, adapter|
-  ADAPTERS = ['grep', 'ag', 'ack', 'git']
+  ADAPTERS = ['grep', 'ag', 'rg', 'ack', 'git']
 
   ADAPTERS.each do |adapter|
     context "with #{adapter} adapter" do


### PR DESCRIPTION
Issue #9

Couldn't get the tests to run. After `bundle`, `bundle exec rake test` throws a bunch of errors that look like

```
       Failure/Error: vim = Vimrunner.start_gvim

       Vimrunner::NoSuitableVimError:
         No suitable Vim executable could be found for this system.
       Shared Example Group: "a backend" called from ./spec/plugin/backend/system_spec.rb:9
```

Note that I made `rg` the first option in opts.vim. This is up to your discretion whether you want it to be there.