### PR TITLE
Fix opening results from 'win' output on windows

### DIFF
--- a/autoload/esearch/out/win.vim
+++ b/autoload/esearch/out/win.vim
@@ -219,8 +219,14 @@ fu! s:render_results(bufnr, parsed, esearch) abort
   let i = 0
   let limit = len(parsed)
 
+  if has('win32')
+    let sub_expression = substitute(a:esearch.cwd, '\\', '\\\\', 'g').'\\'
+  else
+    let sub_expression = a:esearch.cwd.'/'
+  endif
+
   while i < limit
-    let filename    = substitute(parsed[i].filename, a:esearch.cwd.'/', '', '')
+    let filename    = substitute(parsed[i].filename, sub_expression, '', '')
     let context  = s:context(parsed[i].text, a:esearch)
 
     if filename !=# a:esearch.prev_filename


### PR DESCRIPTION
I discovered this issue when using vim on windows with vim-esearch. If there was a result in "C:\temp\test.c" and it were selected to open it would try to open "C:\temp\C:\temp\test.c" because the substitution that is made when rendering the results was not removing e-searches cwd from the file path. This patch makes the substitution pattern correct for removing the cwd from the windows style path.