### PR TITLE
Fix vim8 backend shell command on windows

### DIFF
--- a/autoload/esearch/backend/vim8.vim
+++ b/autoload/esearch/backend/vim8.vim
@@ -17,7 +17,7 @@ fu! esearch#backend#vim8#init(cmd, pty) abort
   let request = {
         \ 'internal_job_id': s:incrementable_internal_id,
         \ 'jobstart_args': {
-        \   'cmd': ['sh', '-c', a:cmd],
+        \   'cmd': [&shell, &shellcmdflag, a:cmd],
         \   'opts': {
         \     'out_cb': function('s:stdout', [s:incrementable_internal_id]),
         \     'err_cb': function('s:stderr', [s:incrementable_internal_id]),


### PR DESCRIPTION
"sh -c" is not appropriate on windows and vim is able to provide the proper shell command and flags so this change utilizes that.

I have tested that this fix works on both windows and linux.