### PR TITLE
Fix nvim backend shell command on windows

### DIFF
--- a/autoload/esearch/backend/nvim.vim
+++ b/autoload/esearch/backend/nvim.vim
@@ -11,7 +11,7 @@ fu! esearch#backend#nvim#init(cmd, pty) abort
   let request = {
         \ 'internal_job_id': s:incrementable_internal_id,
         \ 'jobstart_args': {
-        \   'cmd': ['sh', '-c', a:cmd],
+        \   'cmd': [&shell, &shellcmdflag, a:cmd],
         \   'opts': {
         \     'on_stdout': function('s:stdout'),
         \     'on_stderr': function('s:stderr'),


### PR DESCRIPTION
The same problem as the vim8 backend existed for the nvim backend. This fixes it the same way as b1aac2ad5670501dd721a0209674578120a21b27 
