### PR TITLE
Fix window updates performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,10 +108,10 @@ jobs:
       # Although travis has less cores than 4, it's better for splitting as
       # groups with even execution time cannot be precisely determined using files size
     - name: 'Acceptance tests of window output 1'
-      script: bundle exec parallel_test spec/plugin/window -n 8 --only-group 1,2,3,4 --group-by filesize --type rspec
+      script: bundle exec parallel_test spec/plugin/window -n 8 --only-group 1,2,5,6 --group-by filesize --type rspec
       os: linux
     - name: 'Acceptance tests of window output 2'
-      script: bundle exec parallel_test spec/plugin/window -n 8 --only-group 5,6,7,8 --group-by filesize --type rspec
+      script: bundle exec parallel_test spec/plugin/window -n 8 --only-group 3,4,7,8 --group-by filesize --type rspec
       os: linux
 
     # Linux acceptance

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,17 +92,17 @@ jobs:
     #   - underlying backends (mostly vimproc) rely platform specific calls
     # OSX acceptance
     - name: 'Acceptance tests of #backend#system'
-      script: bundle exec rake RSPEC_OPTS='--tag system'
+      script: PARALLEL_SPLIT_TEST_PROCESSES=2 bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag system
       os: osx
     # - name: 'Acceptance tests of #backend#nvim'
-    #   script: bundle exec rake RSPEC_OPTS='--tag nvim' --seed 6880
+    #   script: PARALLEL_SPLIT_TEST_PROCESSES=2 bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag nvim' --seed 6880
     #   env: INSTALL_PYTHON_VERSION=3.6.1 NVIM_GUI=0
     #   os: osx
     - name: 'Acceptance tests of #backend#vim8'
-      script: bundle exec rake RSPEC_OPTS='--tag vim8'
+      script: PARALLEL_SPLIT_TEST_PROCESSES=2 bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag vim8
       os: osx
     - name: 'Acceptance tests of #backend#vimproc'
-      script: bundle exec rake RSPEC_OPTS='--tag vimproc'
+      script: PARALLEL_SPLIT_TEST_PROCESSES=2 bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag vimproc
       os: osx
 
       # Although travis has less cores than 4, it's better for splitting as
@@ -116,7 +116,7 @@ jobs:
 
     # Linux acceptance
     - name: 'Acceptance tests of #backend#system'
-      script: bundle exec rake RSPEC_OPTS='--tag system'
+      script: PARALLEL_SPLIT_TEST_PROCESSES=2 bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag system
       os: linux
     #  TODO
     # - name: 'Acceptance tests of #backend#nvim'
@@ -125,10 +125,10 @@ jobs:
     #   services: docker
     #   os: linux
     - name: 'Acceptance tests of #backend#vim8'
-      script: bundle exec rake RSPEC_OPTS='--tag vim8'
+      script: PARALLEL_SPLIT_TEST_PROCESSES=2 bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag vim8
       os: linux
     - name: 'Acceptance tests of #backend#vimproc'
-      script: bundle exec rake RSPEC_OPTS='--tag vimproc'
+      script: PARALLEL_SPLIT_TEST_PROCESSES=2 bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag vimproc
       os: linux
 
     - name: 'Acceptance tests of adapter'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 ruby '2.7.0'
 
 gem 'activesupport'
+gem 'parallel_split_test'
 gem 'parallel_tests'
 gem 'pry'
 gem 'racc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,9 @@ GEM
     method_source (0.9.2)
     minitest (5.14.0)
     parallel (1.19.1)
+    parallel_split_test (0.7.0)
+      parallel (>= 0.5.13)
+      rspec (>= 3.1.0)
     parallel_tests (2.31.0)
       parallel
     parser (2.7.0.2)
@@ -62,6 +65,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  parallel_split_test
   parallel_tests
   pry
   racc

--- a/autoload/esearch.vim
+++ b/autoload/esearch.vim
@@ -52,6 +52,7 @@ fu! s:new(configuration) abort
         \ deepcopy(g:esearch), 'keep')
   let configuration = extend(configuration, {
         \ 'cwd': getcwd(),
+        \ 'escaped_cwd': fnameescape(getcwd()),
         \ 'paths': [],
         \ 'metadata': [],
         \ 'glob': 0,
@@ -60,6 +61,13 @@ fu! s:new(configuration) abort
         \ 'set_default': function('esearch#util#set_default'),
         \ 'slice': function('esearch#util#slice')
         \}, 'keep')
+
+  if has('win32')
+    let configuration.cwd_prefix_regex = substitute(configuration.cwd, '\\', '\\\\', 'g').'\\'
+  else
+    let configuration.cwd_prefix_regex = configuration.cwd . '/'
+  endif
+
   return configuration
 endfu
 

--- a/autoload/esearch.vim
+++ b/autoload/esearch.vim
@@ -63,9 +63,9 @@ fu! s:new(configuration) abort
         \}, 'keep')
 
   if has('win32')
-    let configuration.cwd_prefix_regex = substitute(configuration.cwd, '\\', '\\\\', 'g').'\\'
+    let configuration.cwd_prefix = substitute(configuration.cwd, '\\', '\\\\', 'g').'\\'
   else
-    let configuration.cwd_prefix_regex = configuration.cwd . '/'
+    let configuration.cwd_prefix = configuration.cwd . '/'
   endif
 
   return configuration

--- a/autoload/esearch/adapter/ack.vim
+++ b/autoload/esearch/adapter/ack.vim
@@ -35,16 +35,16 @@ endfu
 
 fu! esearch#adapter#ack#set_results_parser(esearch) abort
   if a:esearch.is_single_file()
-    let a:esearch.parse_results = function('esearch#adapter#ack#parse_results_from_single_file')
+    let a:esearch.parse = function('esearch#adapter#ack#parse_from_1_file')
   else
-    let a:esearch.parse_results = function('esearch#adapter#ag_like#parse_results')
+    let a:esearch.parse = function('esearch#adapter#ag_like#parse')
     let a:esearch.format = g:esearch#adapter#ag_like#multiple_files_Search_format
   endif
 
   let a:esearch.expand_filename = function('esearch#adapter#ag_like#expand_filename')
 endfu
 
-fu! esearch#adapter#ack#parse_results_from_single_file(data, from, to) abort dict
+fu! esearch#adapter#ack#parse_from_1_file(data, from, to) abort dict
   if empty(a:data) | return [] | endif
   let results = []
 

--- a/autoload/esearch/adapter/ag_like.vim
+++ b/autoload/esearch/adapter/ag_like.vim
@@ -16,10 +16,19 @@ fu! esearch#adapter#ag_like#set_results_parser(esearch) abort
     let a:esearch.parse = function('esearch#adapter#ag_like#parse_from_1_file')
     let a:esearch.format = g:esearch#adapter#ag_like#single_file_search_format
   else
-    let a:esearch.parse = function('esearch#adapter#ag_like#parse')
-    let a:esearch.format = g:esearch#adapter#ag_like#multiple_files_Search_format
+    if g:esearch#has#getqflist_lines
+      let a:esearch.parse =
+            \ function('esearch#adapter#ag_like#parse_with_getqflist_lines')
+    elseif g:esearch#has#getqflist_text
+      let a:esearch.parse =
+            \ function('esearch#adapter#ag_like#parse_with_getqflist_text')
+    else
+      let a:esearch.parse = function('esearch#adapter#ag_like#parse')
+      let a:esearch.format = g:esearch#adapter#ag_like#multiple_files_Search_format
+    endif
   endif
 
+  let a:esearch.data1 = []
   let a:esearch.expand_filename = function('esearch#adapter#ag_like#expand_filename')
 endfu
 
@@ -52,8 +61,39 @@ fu! esearch#adapter#ag_like#parse_from_1_file(data, from, to) abort dict
   return results
 endfu
 
-fu! esearch#adapter#ag_like#parse(data, from, to) abort dict
+fu! esearch#adapter#ag_like#parse_with_getqflist_lines(data, from, to) abort dict
   if empty(a:data) | return [] | endif
+  try
+    let save_cwd = getcwd()
+    if !empty(self.cwd)
+      exe 'lcd' self.cwd
+    endif
+
+    return getqflist({'lines': a:data[a:from : a:to], 'efm': '%f:%l:%c:%m'}).items
+  finally
+    if !empty(save_cwd)
+      exe 'lcd' save_cwd
+    endif
+  endtry
+endfu
+
+fu! esearch#adapter#ag_like#parse_with_getqflist_text(data, from, to) abort dict
+  if empty(a:data) | return [] | endif
+  try
+    let save_cwd = getcwd()
+    if !empty(self.cwd)
+      exe 'lcd' self.cwd
+    endif
+
+    return getqflist({'text': a:data[a:from : a:to], 'efm': '%f:%l:%c:%m'}).items
+  finally
+    if !empty(save_cwd)
+      exe 'lcd' save_cwd
+    endif
+  endtry
+endfu
+
+fu! esearch#adapter#ag_like#parse(data, from, to) abort dict
   let format = self.format
   let results = []
 

--- a/autoload/esearch/adapter/ag_like.vim
+++ b/autoload/esearch/adapter/ag_like.vim
@@ -69,7 +69,7 @@ fu! esearch#adapter#ag_like#parse_with_getqflist_lines(data, from, to) abort dic
       exe 'lcd' self.cwd
     endif
 
-    return getqflist({'lines': a:data[a:from : a:to], 'efm': '%f:%l:%c:%m'}).items
+    return filter(getqflist({'lines': a:data[a:from : a:to], 'efm': '%f:%l:%c:%m'}).items, 'v:val.valid')
   finally
     if !empty(save_cwd)
       exe 'lcd' save_cwd

--- a/autoload/esearch/adapter/ag_like.vim
+++ b/autoload/esearch/adapter/ag_like.vim
@@ -13,10 +13,10 @@ endfu
 
 fu! esearch#adapter#ag_like#set_results_parser(esearch) abort
   if a:esearch.is_single_file()
-    let a:esearch.parse_results = function('esearch#adapter#ag_like#parse_results_from_single_file')
+    let a:esearch.parse = function('esearch#adapter#ag_like#parse_from_1_file')
     let a:esearch.format = g:esearch#adapter#ag_like#single_file_search_format
   else
-    let a:esearch.parse_results = function('esearch#adapter#ag_like#parse_results')
+    let a:esearch.parse = function('esearch#adapter#ag_like#parse')
     let a:esearch.format = g:esearch#adapter#ag_like#multiple_files_Search_format
   endif
 
@@ -27,7 +27,7 @@ fu! esearch#adapter#ag_like#expand_filename(filename) abort dict
   return a:filename
 endfu
 
-fu! esearch#adapter#ag_like#parse_results_from_single_file(data, from, to) abort dict
+fu! esearch#adapter#ag_like#parse_from_1_file(data, from, to) abort dict
   if empty(a:data) | return [] | endif
   let format = self.format
   let results = []
@@ -52,7 +52,7 @@ fu! esearch#adapter#ag_like#parse_results_from_single_file(data, from, to) abort
   return results
 endfu
 
-fu! esearch#adapter#ag_like#parse_results(data, from, to) abort dict
+fu! esearch#adapter#ag_like#parse(data, from, to) abort dict
   if empty(a:data) | return [] | endif
   let format = self.format
   let results = []

--- a/autoload/esearch/adapter/git.vim
+++ b/autoload/esearch/adapter/git.vim
@@ -40,7 +40,7 @@ fu! esearch#adapter#git#cmd(esearch, pattern, escape) abort
 endfu
 
 fu! esearch#adapter#git#set_results_parser(esearch) abort
-  let a:esearch.parse_results = function('esearch#adapter#grep_like#parse_results')
+  let a:esearch.parse = function('esearch#adapter#grep_like#parse')
   let a:esearch.format = g:esearch#adapter#grep_like#multiple_files_Search_format
   let a:esearch.expand_filename = function('<SID>expand_filename')
 endfu

--- a/autoload/esearch/adapter/grep_like.vim
+++ b/autoload/esearch/adapter/grep_like.vim
@@ -19,17 +19,17 @@ endfu
 
 fu! esearch#adapter#grep_like#set_results_parser(esearch) abort
   if a:esearch.is_single_file()
-    let a:esearch.parse_results = function('esearch#adapter#grep_like#parse_results_from_single_file')
+    let a:esearch.parse = function('esearch#adapter#grep_like#parse_from_1_file')
     let a:esearch.format = g:esearch#adapter#grep_like#single_file_search_format
   else
-    let a:esearch.parse_results = function('esearch#adapter#grep_like#parse_results')
+    let a:esearch.parse = function('esearch#adapter#grep_like#parse')
     let a:esearch.format = g:esearch#adapter#grep_like#multiple_files_Search_format
   endif
 
   let a:esearch.expand_filename = function('esearch#adapter#ag_like#expand_filename')
 endfu
 
-fu! esearch#adapter#grep_like#parse_results_from_single_file(data, from, to) abort dict
+fu! esearch#adapter#grep_like#parse_from_1_file(data, from, to) abort dict
   if empty(a:data) | return [] | endif
   let format = self.format
   let results = []
@@ -58,7 +58,7 @@ fu! esearch#adapter#grep_like#parse_results_from_single_file(data, from, to) abo
   return results
 endfu
 
-fu! esearch#adapter#grep_like#parse_results(data, from, to) abort dict
+fu! esearch#adapter#grep_like#parse(data, from, to) abort dict
   if empty(a:data) | return [] | endif
   let format = self.format
   let results = []

--- a/autoload/esearch/adapter/pt.vim
+++ b/autoload/esearch/adapter/pt.vim
@@ -34,7 +34,7 @@ fu! esearch#adapter#pt#cmd(esearch, pattern, escape) abort
 endfu
 
 fu! esearch#adapter#pt#set_results_parser(esearch) abort
-  let a:esearch.parse_results = function('esearch#adapter#ag_like#parse_results')
+  let a:esearch.parse = function('esearch#adapter#ag_like#parse')
   let a:esearch.format = g:esearch#adapter#ag_like#multiple_files_Search_format
   let a:esearch.expand_filename = function('esearch#adapter#ag_like#expand_filename')
 endfu

--- a/autoload/esearch/backend/nvim.vim
+++ b/autoload/esearch/backend/nvim.vim
@@ -31,7 +31,7 @@ fu! esearch#backend#nvim#init(cmd, pty) abort
         \ 'async': 1,
         \ 'aborted': 0,
         \ 'events': {
-        \   'forced_finish': 'ESearchNVimFinish'.s:incrementable_internal_id,
+        \   'schedule_finish': 'ESearchNVimFinish'.s:incrementable_internal_id,
         \   'update': 'ESearchNVimUpdate'.s:incrementable_internal_id
         \ }
         \}
@@ -99,7 +99,7 @@ fu! s:exit(job_id, status, event) abort
   let job.request.finished = 1
   let job.request.status = a:status
   if !job.request.aborted
-    exe 'do User '.job.request.events.forced_finish
+    exe 'do User '.job.request.events.schedule_finish
   endif
 endfu
 

--- a/autoload/esearch/backend/vim8.vim
+++ b/autoload/esearch/backend/vim8.vim
@@ -43,7 +43,7 @@ fu! esearch#backend#vim8#init(cmd, pty) abort
         \ 'async': 1,
         \ 'aborted': 0,
         \ 'events': {
-        \   'forced_finish': 'ESearchvim8Finish'.s:incrementable_internal_id,
+        \   'schedule_finish': 'ESearchvim8Finish'.s:incrementable_internal_id,
         \   'update': 'ESearchvim8Update'.s:incrementable_internal_id
         \ }
         \}
@@ -92,7 +92,7 @@ endfunc
 func! s:watch_for_buffered_data_render_complete(job, timer) abort
   " dirty check
   if a:job.request.cursor == a:job.request.old_cursor
-    exe 'do User '.a:job.request.events.forced_finish
+    exe 'do User '.a:job.request.events.schedule_finish
     call timer_start(0, function('s:timer_stop_workaround', [a:job]))
   else
     let a:job.request.old_cursor = a:job.request.cursor
@@ -105,7 +105,7 @@ fu! s:closed(job_id, channel) abort
 
   " TODO should be properly tested first
   if esearch#util#vim8_calls_close_cb_last()
-    exe 'do User '.job.request.events.forced_finish
+    exe 'do User '.job.request.events.schedule_finish
   else
     let job.request.timer_id = timer_start(g:esearch#backend#vim8#timer,
           \ function('s:watch_for_buffered_data_render_complete', [job]),

--- a/autoload/esearch/has.vim
+++ b/autoload/esearch/has.vim
@@ -1,1 +1,3 @@
 let g:esearch#has#debounce = has('timers')
+let g:esearch#has#getqflist_text = has('patch8.0.1006')
+let g:esearch#has#getqflist_lines = has('patch8.0.1031')

--- a/autoload/esearch/opts.vim
+++ b/autoload/esearch/opts.vim
@@ -24,6 +24,7 @@ fu! esearch#opts#new(opts) abort
         \ 'case':             0,
         \ 'word':             0,
         \ 'batch_size':       800,
+        \ 'last_batch_size':  4*800,
         \ 'context_width':    { 'left': 60, 'right': 60 },
         \ 'highlight_match':  1,
         \ 'default_mappings': g:esearch#defaults#default_mappings,

--- a/autoload/esearch/opts.vim
+++ b/autoload/esearch/opts.vim
@@ -23,7 +23,7 @@ fu! esearch#opts#new(opts) abort
         \ 'regex':            0,
         \ 'case':             0,
         \ 'word':             0,
-        \ 'batch_size':       500,
+        \ 'batch_size':       800,
         \ 'context_width':    { 'left': 60, 'right': 60 },
         \ 'highlight_match':  1,
         \ 'default_mappings': g:esearch#defaults#default_mappings,

--- a/autoload/esearch/out/qflist.vim
+++ b/autoload/esearch/out/qflist.vim
@@ -88,10 +88,6 @@ fu! esearch#out#qflist#update() abort
 
     let parsed = esearch.parse(data, from, to)
 
-    for p in parsed
-      let p.filename = fnamemodify(p.filename, ':~:.')
-    endfor
-
     if esearch#util#qftype(bufnr('%')) ==# 'qf'
       let curpos = getcurpos()[1:]
       noau call setqflist(parsed, 'a')
@@ -152,9 +148,9 @@ endfu
 fu! s:init_commands() abort
   let s:win = {
         \ 'line_in_file':   function('s:line_in_file'),
-        \ 'open':          function('s:open'),
-        \ 'filename':      function('s:filename'),
-        \ 'is_file_entry': function('s:is_file_entry')
+        \ 'open':           function('s:open'),
+        \ 'filename':       function('s:filename'),
+        \ 'is_file_entry':  function('s:is_file_entry')
         \}
   command! -nargs=1 -range=0 -bar -buffer  -complete=custom,esearch#substitute#complete ESubstitute
         \ call esearch#substitute#do(<q-args>, <line1>, <line2>, s:win)

--- a/autoload/esearch/out/qflist.vim
+++ b/autoload/esearch/out/qflist.vim
@@ -86,7 +86,7 @@ fu! esearch#out#qflist#update() abort
       let request.cursor += esearch.batch_size
     endif
 
-    let parsed = esearch.parse_results(data, from, to)
+    let parsed = esearch.parse(data, from, to)
 
     for p in parsed
       let p.filename = fnamemodify(p.filename, ':~:.')
@@ -102,7 +102,7 @@ fu! esearch#out#qflist#update() abort
   endif
 endfu
 
-fu! esearch#out#qflist#forced_finish() abort
+fu! esearch#out#qflist#schedule_finish() abort
   call esearch#out#qflist#finish()
 endfu
 

--- a/autoload/esearch/out/win.vim
+++ b/autoload/esearch/out/win.vim
@@ -412,17 +412,15 @@ fu! s:render_results(bufnr, parsed, esearch) abort
 
   let i = 0
   let limit = len(parsed)
-
-  if has('win32')
-    let sub_expression = substitute(a:esearch.cwd, '\\', '\\\\', 'g').'\\'
-  else
-    let sub_expression = a:esearch.cwd.'/'
-  endif
-
   let lines = []
 
   while i < limit
-    let filename = substitute(parsed[i].filename, sub_expression, '', '')
+    if has_key(parsed[i], 'bufnr')
+      let filename = bufname(parsed[i].bufnr)
+    else
+      let filename = substitute(parsed[i].filename, a:esearch.cwd_prefix_regex, '', '')
+    endif
+
     if g:esearch_win_ellipsize_results
       let text = esearch#util#ellipsize(
             \ parsed[i].text,
@@ -445,14 +443,12 @@ fu! s:render_results(bufnr, parsed, esearch) abort
       end
 
       call add(lines, '')
-      " call esearch#util#setline(a:bufnr, line, '')
       call add(a:esearch.context_ids_map, a:esearch.contexts[-1].id)
       call add(a:esearch.columns_map, 0)
       call add(a:esearch.line_numbers_map, 0)
       let line += 1
 
       call add(lines, filename)
-      " call esearch#util#setline(a:bufnr, line, filename)
       call s:add_context(a:esearch.contexts, filename, line)
       let a:esearch.context_by_name[filename] = a:esearch.contexts[-1]
       call add(a:esearch.context_ids_map, a:esearch.contexts[-1].id)
@@ -464,7 +460,6 @@ fu! s:render_results(bufnr, parsed, esearch) abort
     endif
 
     call add(lines, printf(' %3d %s', parsed[i].lnum, text))
-    " call esearch#util#setline(a:bufnr, line, printf(' %3d %s', parsed[i].lnum, text))
     call add(a:esearch.columns_map, parsed[i].col)
     call add(a:esearch.line_numbers_map, parsed[i].lnum)
     call add(a:esearch.context_ids_map, a:esearch.contexts[-1].id)

--- a/autoload/esearch/out/win.vim
+++ b/autoload/esearch/out/win.vim
@@ -155,9 +155,8 @@ fu! esearch#out#win#init(opts) abort
         \ 'bufnr':                    bufnr('%'),
         \ 'last_update_at':           reltime(),
         \ 'files_count':              0,
-        \ 'lines_count':              0,
         \ 'viewport_highlight_timer': -1,
-        \ 'updates_timer':             -1,
+        \ 'updates_timer':            -1,
         \ 'update_with_timer_start':  0,
         \ 'max_lines_found':          0,
         \ 'ignore_batches':           0,
@@ -374,13 +373,13 @@ fu! esearch#out#win#update(bufnr) abort
   let spinner = s:spinner[esearch.tick / s:spinner_slowdown % s:spinner_frames_size]
   if request.finished
     call esearch#util#setline(a:bufnr, 1, printf(s:request_finished_header,
-          \ esearch.lines_count,
+          \ len(esearch.request.data),
           \ esearch.files_count,
           \ spinner
           \ ))
   else
     call esearch#util#setline(a:bufnr, 1, printf(s:header,
-          \ esearch.lines_count,
+          \ len(esearch.request.data),
           \ spinner,
           \ esearch.files_count,
           \ spinner
@@ -472,7 +471,6 @@ fu! s:render_results(bufnr, parsed, esearch) abort
     let i    += 1
   endwhile
 
-  let a:esearch.lines_count += len(lines)
   call esearch#util#append_lines(lines)
 endfu
 
@@ -719,10 +717,10 @@ endfu
 fu! esearch#out#win#foldtext() abort
   let filename = getline(v:foldstart)
   let last_line = getline(v:foldend)
-  let lines_count = v:foldend - v:foldstart - (empty(last_line) ? 1 : 0)
+  let entries_count = v:foldend - v:foldstart - (empty(last_line) ? 1 : 0)
 
   let winwidth = winwidth(0) - &foldcolumn - (&number ? strwidth(string(line('$'))) + 1 : 0)
-  let lines_count_str = lines_count . ' line(s)'
+  let lines_count_str = entries_count . ' line(s)'
 
   let expansion = repeat('-', winwidth - strwidth(filename.lines_count_str))
 
@@ -857,8 +855,8 @@ fu! esearch#out#win#finish(bufnr) abort
     endfor
   else
     call esearch#util#setline(a:bufnr, 1, printf(s:finished_header,
-          \ esearch.lines_count,
-          \ esearch#inflector#pluralize('line', esearch.lines_count),
+          \ len(esearch.request.data),
+          \ esearch#inflector#pluralize('line', len(esearch.request.data)),
           \ esearch.files_count,
           \ esearch#inflector#pluralize('file', b:esearch.files_count),
           \))
@@ -1026,8 +1024,8 @@ fu! s:handle_insert__inline(event) abort
 
   if line1 == 1
     call setline(line1, printf(s:finished_header,
-          \ b:esearch.lines_count,
-          \ esearch#inflector#pluralize('line', b:esearch.lines_count),
+          \ len(b:esearch.request.data),
+          \ esearch#inflector#pluralize('line', len(b:esearch.request.data)),
           \ b:esearch.files_count,
           \ esearch#inflector#pluralize('file', b:esearch.files_count),
           \ ))
@@ -1086,8 +1084,8 @@ fu! s:handle_normal__inline(event) abort
 
   if line1 == 1
     call setline(line1, printf(s:finished_header,
-          \ b:esearch.lines_count,
-          \ esearch#inflector#pluralize('line', b:esearch.lines_count),
+          \ len(b:esearch.request.data),
+          \ esearch#inflector#pluralize('line', len(b:esearch.request.data)),
           \ b:esearch.files_count,
           \ esearch#inflector#pluralize('file', b:esearch.files_count),
           \ ))
@@ -1146,8 +1144,8 @@ endfu
 fu! s:handle_motion__header(recover) abort
   if a:recover.line1 == 1
     let a:recover.add_lines += [printf(s:finished_header,
-          \ b:esearch.lines_count,
-          \ esearch#inflector#pluralize('line', b:esearch.lines_count),
+          \ len(b:esearch.request.data),
+          \ esearch#inflector#pluralize('line', len(b:esearch.request.data)),
           \ b:esearch.files_count,
           \ esearch#inflector#pluralize('file', b:esearch.files_count),
           \ )]

--- a/autoload/esearch/out/win.vim
+++ b/autoload/esearch/out/win.vim
@@ -356,7 +356,10 @@ fu! esearch#out#win#update(bufnr) abort
 
   call setbufvar(a:bufnr, '&ma', 1)
   if data_size > request.cursor
-    if ignore_batches || data_size - request.cursor - 1 <= esearch.batch_size
+    " TODO consider to discard ignore_batches as it doesn't make a lot of sense
+    if ignore_batches
+          \ || data_size - request.cursor - 1 <= esearch.batch_size
+          \ || (request.finished && data_size - request.cursor - 1 <= esearch.last_batch_size)
       let [from, to] = [request.cursor, data_size - 1]
       let request.cursor = data_size
     else

--- a/autoload/esearch/util.vim
+++ b/autoload/esearch/util.vim
@@ -3,8 +3,22 @@ let s:Highlight = s:Vital.import('Vim.Highlight')
 let s:Message   = s:Vital.import('Vim.Message')
 
 fu! esearch#util#setline(_, lnum, text) abort
-  return setline(a:lnum, a:text)
+  " call nvim_buf_set_lines(a:_, a:lnum - 1, a:lnum, 0, [a:text])
+  call setline(a:lnum, a:text)
 endfu
+
+
+if has('nvim')
+  fu! esearch#util#append_lines(lines) abort
+    call nvim_buf_set_lines(bufnr('%'), -1, -1, 0, a:lines)
+  endfu
+else
+  fu! esearch#util#append_lines(lines) abort
+    for l in a:lines
+      call append(line('$'), l)
+    endfor
+  endfu
+endif
 
 if !exists('g:esearch#util#unicode_enabled')
   let g:esearch#util#unicode_enabled = 1

--- a/spec/plugin/shared_examples/abortable_backend.rb
+++ b/spec/plugin/shared_examples/abortable_backend.rb
@@ -9,7 +9,9 @@ RSpec.shared_examples 'an abortable backend' do |backend|
   let(:empty_cwd_for_infinite_search) { '' }
   # We will identify our command using UUID search_string (generated as a static
   # string intetionally)
-  let(:search_string) { '550e8400-e29b-41d4-a716-446655440000' }
+  let(:search_string) do
+    "550e8400-e29b-41d4-a716-446655440000#{Configuration.test_env_number}"
+  end
   let(:command_pattern) { search_string }
   # sh script spawns a main search process, so we have to ignore it to avoid
   # working with two process (parent and child)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -125,7 +125,7 @@ VimrunnerNeovim::RSpec.configure do |c|
 
   c.start_nvim do
     load_runtime!(Client.new(Server.neovim(
-      name:          "NVIMRUNER#{Time.now.to_f}#{ENV['TEST_ENV_NUMBER']}",
+      name:          "NVIMRUNER#{Time.now.to_f}#{Configuration.test_env_number}",
       nvim:          Configuration.nvim_path,
       gui:           Configuration.nvim_gui?,
       vimrc:         Configuration.vimrc_path,

--- a/spec/support/configuration.rb
+++ b/spec/support/configuration.rb
@@ -24,6 +24,13 @@ module Configuration
     env_fetch('RG_PATH') { bin_dir.join('rg') }
   end
 
+  def test_env_number
+    # For parallel_tests and parallel_split_test
+    # Imitation of --first-is-1 of parallel_tests for parallel_split_test as it
+    # doesn't have this option
+    env_fetch('TEST_ENV_NUMBER') { '1' }
+  end
+
   def log_level
     env_fetch('LOG_LEVEL') { 'info' }
   end

--- a/spec/support/profiling/profile.vim
+++ b/spec/support/profiling/profile.vim
@@ -1,8 +1,11 @@
 profile start profile.log
 profile file *
 profile func *
-command KK profile stop | edit profile.log
+
+if has('nvim')
+  command KK profile stop | edit profile.log
+else
+  command KK qall
+endif
 
 call esearch#init()
-
-" profile stop


### PR DESCRIPTION
- batched setline(), parsing with getqflist() (about 1.5x speed increase)
- show results from the first batch using backend callbacks (results in an early render before the first timer cb run)
- use separate size value for the last batch to show data earlier when the backend is already finished
- parallelize backend specs