### PR TITLE
Bugfix 2

### DIFF
--- a/autoload/esearch/backend/vim8.vim
+++ b/autoload/esearch/backend/vim8.vim
@@ -36,6 +36,7 @@ fu! esearch#backend#vim8#init(cmd, pty) abort
         \ 'tick': 0,
         \ 'ticks': g:esearch#backend#vim8#ticks,
         \ 'backend':  'vim8',
+        \ 'intermediate':  '',
         \ 'command':  a:cmd,
         \ 'data':     [],
         \ 'errors':     [],
@@ -63,6 +64,15 @@ endfu
 fu! s:stdout(job_id, job, data) abort
   let request = s:jobs[a:job_id].request
   let data = split(a:data, "\n", 1)
+
+  if !empty(request.intermediate) && !empty(data)
+    let data[0] = request.intermediate . data[0]
+    let request.intermediate = ''
+  endif
+  if !empty(data) && data[-1] !~# '\r$'
+    let request.intermediate = remove(data, -1)
+  endif
+
   let request.data += filter(data, "'' !=# v:val")
   if !request.aborted && request.tick % request.ticks == 1 && !empty(request.events.update)
     call request.events.update()

--- a/autoload/esearch/out/win/matches.vim
+++ b/autoload/esearch/out/win/matches.vim
@@ -26,6 +26,10 @@ fu! esearch#out#win#matches#init_highlight(esearch) abort
 endfu
 
 fu! s:highlight_matches_callback(esearch, callback) abort
+  if !exists('b:esearch') || b:esearch.id != a:esearch.id
+    return
+  endif
+
   let [top, bottom] = [ line('w0'), line('w$') ]
   let last_hl_range = a:esearch.last_hl_range
 

--- a/autoload/esearch/out/win/render/lua.vim
+++ b/autoload/esearch/out/win/render/lua.vim
@@ -92,6 +92,11 @@ function esearch_out_win_render_nvim(data, path, cwd_prefix, last_context, files
   local context_by_name = {}
   local esearch_win_disable_context_highlights_on_files_count =
     vim.api.nvim_get_var('esearch_win_disable_context_highlights_on_files_count')
+  local unload_context_syntax_on_line_length =
+    vim.api.nvim_get_var('unload_context_syntax_on_line_length')
+  local unload_global_syntax_on_line_length =
+    vim.api.nvim_get_var('unload_global_syntax_on_line_length')
+
 
   local start = vim.api.nvim_buf_line_count(0)
   local line = start
@@ -135,6 +140,14 @@ function esearch_out_win_render_nvim(data, path, cwd_prefix, last_context, files
       files_count = files_count + 1
       line = line + 1
       contexts[#contexts]['filename'] = filename
+    end
+
+    if text:len() > unload_context_syntax_on_line_length then
+      if text:len() > unload_global_syntax_on_line_length then
+        vim.api.nvim_eval('esearch#out#win#_blocking_unload_syntaxes(b:esearch)')
+      else
+        contexts[#contexts]['syntax_loaded'] = -1
+      end
     end
 
     linenr_text = string.format(' %3d ', parsed[i]['lnum'])
@@ -218,6 +231,10 @@ function esearch_out_win_render_vim(data, path, cwd_prefix, esearch)
   local context_by_name  = esearch['context_by_name']
   local esearch_win_disable_context_highlights_on_files_count =
     vim.eval('g:esearch_win_disable_context_highlights_on_files_count')
+  local unload_context_syntax_on_line_length =
+    vim.eval('g:unload_context_syntax_on_line_length')
+  local unload_global_syntax_on_line_length =
+    vim.eval('g:unload_global_syntax_on_line_length')
 
   local b = vim.buffer()
   local line = vim.eval('line("$") + 1')
@@ -260,6 +277,14 @@ function esearch_out_win_render_vim(data, path, cwd_prefix, esearch)
       files_count = files_count + 1
       line = line + 1
       contexts[#contexts - 1]['filename'] = filename
+    end
+
+    if text:len() > unload_context_syntax_on_line_length then
+      if text:len() > unload_global_syntax_on_line_length then
+        vim.eval('esearch#out#win#_blocking_unload_syntaxes(b:esearch)')
+      else
+        contexts[#contexts - 1]['syntax_loaded'] = -1
+      end
     end
 
     b:insert(string.format(' %3d %s', parsed[i]['lnum'], text))

--- a/autoload/esearch/out/win/render/viml.vim
+++ b/autoload/esearch/out/win/render/viml.vim
@@ -46,6 +46,14 @@ fu! esearch#out#win#render#viml#do(bufnr, data, from, to, esearch) abort
       let a:esearch.contexts[-1].filename = filename
     endif
 
+    if len(text) > g:unload_context_syntax_on_line_length
+      if len(text) > g:unload_global_syntax_on_line_length
+        call esearch#out#win#_blocking_unload_syntaxes(a:esearch)
+      else
+        let a:esearch.contexts[-1].syntax_loaded = -1
+      end
+    end
+
     call add(lines, printf(s:linenr_format, parsed[i].lnum, text))
     call add(a:esearch.line_numbers_map, parsed[i].lnum)
     call add(a:esearch.ctx_ids_map, a:esearch.contexts[-1].id)

--- a/spec/plugin/window/syntax/c_spec.rb
+++ b/spec/plugin/window/syntax/c_spec.rb
@@ -44,7 +44,7 @@ describe 'esearch window context syntax', :window do
 
         // comment line
         /* comment block */
-        /* ellipsized comment #{'.' * 500}*/
+        /* ellipsized comment #{'.' * 300}*/
 
         struct{}
         union{}

--- a/spec/plugin/window/syntax/go_spec.rb
+++ b/spec/plugin/window/syntax/go_spec.rb
@@ -20,7 +20,7 @@ describe 'esearch window context syntax', :window do
         "string"
         "escaped quote\\"
         "str with escape\\n"
-        "ellipsized string#{'.' * 500}"
+        "ellipsized string#{'.' * 300}"
         `raw string`
         defer
         go
@@ -35,7 +35,7 @@ describe 'esearch window context syntax', :window do
         default
         // comment line
         /* comment block */
-        /* ellipsized comment #{'.' * 500}*/
+        /* ellipsized comment #{'.' * 300}*/
         for {}
         range()
       SOURCE

--- a/spec/plugin/window/syntax/java_spec.rb
+++ b/spec/plugin/window/syntax/java_spec.rb
@@ -28,7 +28,7 @@ describe 'esearch window context syntax', :window do
         super
         // comment line
         /* comment block */
-        /* ellipsized comment #{'.' * 500}*/
+        /* ellipsized comment #{'.' * 300}*/
         new
         instanceof
         return

--- a/spec/plugin/window/syntax/javascript_spec.rb
+++ b/spec/plugin/window/syntax/javascript_spec.rb
@@ -38,7 +38,7 @@ describe 'esearch window context syntax', :window do
         // comment line
         /* comment block */
         /* comment block
-        /* ellipsized comment #{'.' * 500}*/
+        /* ellipsized comment #{'.' * 300}*/
         true
         false
         arguments

--- a/spec/plugin/window/syntax/javascriptreact_spec.rb
+++ b/spec/plugin/window/syntax/javascriptreact_spec.rb
@@ -40,7 +40,7 @@ describe 'esearch window context syntax', :window do
         undefined
         // comment line
         /* comment block */
-        /* ellipsized comment #{'.' * 500}*/
+        /* ellipsized comment #{'.' * 300}*/
         true
         false
         arguments

--- a/spec/plugin/window/syntax/php_spec.rb
+++ b/spec/plugin/window/syntax/php_spec.rb
@@ -53,7 +53,7 @@ describe 'esearch window context syntax', :window do
 
         // comment line
         /* comment block */
-        /* ellipsized comment #{'.' * 500}*/
+        /* ellipsized comment #{'.' * 300}*/
         // terminated with ?>
 
         var
@@ -61,7 +61,7 @@ describe 'esearch window context syntax', :window do
 
         # comment
         #comment
-        # ellipsized comment #{'.' * 500}*/
+        # ellipsized comment #{'.' * 300}*/
         # terminated with ?>
 
         namespace

--- a/spec/plugin/window/syntax/python_spec.rb
+++ b/spec/plugin/window/syntax/python_spec.rb
@@ -68,7 +68,7 @@ describe 'esearch window context syntax', :window do
 
         # comment
         #comment
-        # ellipsized comment #{'.' * 500}*/
+        # ellipsized comment #{'.' * 300}*/
 
         and
         in

--- a/spec/plugin/window/syntax/ruby_spec.rb
+++ b/spec/plugin/window/syntax/ruby_spec.rb
@@ -59,7 +59,7 @@ describe 'esearch window context syntax', :window do
 
         # comment
         #comment
-        # ellipsized comment #{'.' * 500}*/
+        # ellipsized comment #{'.' * 300}*/
 
         super
         yield


### PR DESCRIPTION
- Fix vim8 missing data on stdout callback raw data split
- Fix complete editor lock on huge lines by disabling wraps and all the highlights within a window (over 30000 chars; minified js, one-line xml files etc.). 'synmaxcol' option didn't help.
- Fix neovim race condition of timer callbacks when switching to another buffer.
- Fix slowdown on a sequence of big lines (over 500 chars).
- Fix vim7 and vim8 randomly occuring bug when unloading matches highlights.