### PR TITLE
Implement preview window tests

### DIFF
--- a/autoload/esearch/debounce.vim
+++ b/autoload/esearch/debounce.vim
@@ -1,7 +1,25 @@
-fu! esearch#debounce#trailing(callback, wait, timer) abort
-  " TODO investigate how to make it work like a decorator
+" TODO investigate what is faster
+"
+fu! esearch#debounce#_trailing(callback, wait, timer) abort
   if a:timer >= 0
     call timer_stop(a:timer)
   endif
   return timer_start(a:wait, a:callback)
+endfu
+
+fu! esearch#debounce#trailing(callback, wait) abort
+  return {
+        \ '_callback': a:callback,
+        \ '_timer':    -1,
+        \ '_wait':     a:wait,
+        \ 'invoke':    function('<SID>invoke_trailing'),
+        \ }
+endfu
+
+fu! s:invoke_trailing(...) abort dict
+  if self._timer >= 0
+    call timer_stop(self._timer)
+  endif
+
+  let self._timer = timer_start(self._wait, {_ -> call(self._callback, a:000) })
 endfu

--- a/autoload/esearch/has.vim
+++ b/autoload/esearch/has.vim
@@ -5,7 +5,7 @@ let g:esearch#has#nvim_add_highlight = exists('*nvim_buf_clear_namespace') && ex
 let g:esearch#has#virtual_cursor_linenr_highlight = !has('nvim') || g:esearch#has#nvim_add_highlight
 let g:esearch#has#nvim_lua_syntax = exists('*nvim_buf_attach') && g:esearch#has#nvim_add_highlight
 let g:esearch#has#unicode = has('multi_byte') && (&termencoding ==# 'utf-8' || &encoding ==# 'utf-8')
-" Backends
+let g:esearch#has#preview = has('nvim') && exists('*nvim_open_win')
 let g:esearch#has#nvim_jobs = has('nvim') && exists('*jobstart')
 " 7.4.1787 - fix of: channel close callback is invoked before other callbacks
 let g:esearch#has#vim8_calls_close_cb_last = has('patch-7.4.1787')
@@ -13,7 +13,6 @@ let g:esearch#has#vim8_calls_close_cb_last = has('patch-7.4.1787')
 let g:esearch#has#vim8_jobs = has('job') &&
         \ has('patch-7.4.1398') &&
         \ (g:esearch#has#vim8_calls_close_cb_last || exists('*timer_start'))
-
 " Implemented as a function to not preload unneeded code from
 " autoload/vimproc.vim
 fu! esearch#has#vimproc() abort
@@ -27,7 +26,6 @@ fu! esearch#has#vimproc() abort
   endif
   return s:exists_vimproc
 endfu
-
 " 7.3.896 memory leaks in Lua interface
 let s:fixed_lua = (v:version > 703 || v:version == 703 && has('patch896'))
 let g:esearch#has#nvim_lua = has('nvim') && !g:esearch#has#windows && s:fixed_lua

--- a/autoload/esearch/out/win.vim
+++ b/autoload/esearch/out/win.vim
@@ -242,6 +242,7 @@ fu! esearch#out#win#init(opts) abort
         \ 'without':                  function('esearch#util#without'),
         \ 'header_text':              function('s:header_text'),
         \ 'open':                     function('<SID>open'),
+        \ 'preview':                  function('<SID>preview'),
         \})
 
   if b:esearch.request.async
@@ -721,9 +722,9 @@ fu! s:init_mappings() abort
   nnoremap <silent><buffer> <Plug>(esearch-win-prev-file)     :<C-U>sil cal <SID>file_jump(0, v:count1)<CR>
   nnoremap <silent><buffer> <Plug>(esearch-win-next-file)     :<C-U>sil cal <SID>file_jump(1, v:count1)<CR>
 
-  if esearch#preview#is_available()
-    nnoremap <silent><buffer> <S-p> :<C-U>sil cal esearch#preview#start()<CR>
-    nnoremap <silent><buffer> p     :<C-U>sil cal esearch#preview#start()<CR>
+  if g:esearch#has#preview
+    nnoremap <silent><buffer> <S-p> :<C-U>sil cal b:esearch.preview()<CR>
+    nnoremap <silent><buffer> p     :<C-U>sil cal b:esearch.preview()<CR>
   endif
 
   for i in range(0, len(s:mappings) - 1)
@@ -747,6 +748,10 @@ endfu
 
 fu! s:invoke_mapping_callback(i) abort
   call s:mappings[a:i].rhs()
+endfu
+
+fu! s:preview() abort dict
+  return esearch#preview#start(esearch#out#win#filename(), esearch#out#win#line_in_file())
 endfu
 
 fu! s:open(cmd, ...) abort

--- a/autoload/esearch/out/win.vim
+++ b/autoload/esearch/out/win.vim
@@ -770,7 +770,9 @@ fu! s:open(cmd, ...) abort
     endtry
 
     keepjumps call winrestview({'lnum': lnum, 'col': col - 1,'topline': topline })
-    if a:0 | exe a:1 | endif
+    if a:0
+      exe a:1
+    endif
   endif
 endfu
 

--- a/autoload/esearch/out/win/matches.vim
+++ b/autoload/esearch/out/win/matches.vim
@@ -13,7 +13,7 @@ fu! esearch#out#win#matches#init_highlight(esearch) abort
   if g:esearch_out_win_highlight_matches ==# 'viewport'
     augroup ESearchWinHighlights
       let a:esearch.matches_namespace_id = nvim_create_namespace('esearchMatchesNS')
-      au CursorMoved <buffer> let b:esearch.match_highlight_timer = esearch#debounce#trailing(
+      au CursorMoved <buffer> let b:esearch.match_highlight_timer = esearch#debounce#_trailing(
             \ function('s:highlight_matches_callback', [b:esearch]),
             \ g:esearch_win_matches_highlight_debounce_wait,
             \ b:esearch.match_highlight_timer)

--- a/autoload/esearch/preview.vim
+++ b/autoload/esearch/preview.vim
@@ -16,11 +16,6 @@ let s:events = join([
 let s:preview_buffers = {}
 let s:preview_window = s:null
 
-" TODO testing scenarios (currently blocked by editor version)
-"   - file with a name required to be escaped
-"   - new buffers bloat
-"   - bouncing
-"   - buffers with existing swaps
 fu! esearch#preview#start(filename, line) abort
   if !filereadable(a:filename)
     return 0
@@ -182,7 +177,6 @@ endfu
 fu! s:reshape_preview_window(line, height) abort
   let lines_size = line('$')
   exe 'noautocmd keepjumps resize '. a:height
-  resize 10
 
   if lines_size < a:height
     return cursor(a:line, 0)
@@ -208,11 +202,10 @@ fu! s:setup_edited_file_highlight() abort
 endfu
 
 fu! s:open_preview_window(preview_buffer, width, height) abort
-  let p = getpos('.')[1]
-  if line('w$') - p < a:height
-    let row = (getpos('.')[1] - line('w0')) - a:height
+  if  &lines - a:height - 1 < winline()
+    let row = winline() - a:height
   else
-    let row = (getpos('.')[1] - line('w0') + 1)
+    let row = winline()
   endif
 
   let id = nvim_open_win(a:preview_buffer.id, 0, {
@@ -283,7 +276,7 @@ fu! s:create_buffer(filename, disposable) abort
     if bufexists(a:filename)
       return s:preview_buffers[a:filename]
     else
-      " buffer is known as a preview, but it was removed using :bwipeout or the
+      " buffer is known as a preview, but it was removed using :bwipeout or a
       " similar command
       call remove(s:preview_buffers, a:filename)
     endif

--- a/autoload/esearch/preview.vim
+++ b/autoload/esearch/preview.vim
@@ -3,17 +3,17 @@ let s:sign_id = 1
 let s:sign_name = 'ESearchPreviewMatchedLine'
 let s:sign_group = 'ESearchPreviewSigns'
 let s:events = join([
+      \ 'CursorMoved',
       \ 'CmdlineEnter',
       \ 'QuitPre',
       \ 'ExitPre',
-      \ 'CursorMoved',
       \ 'BufEnter',
       \ 'BufWinEnter',
       \ 'WinLeave',
       \ 'BufWinLeave',
       \ 'BufLeave',
       \ ], ',')
-let s:preview_buffers_registry = {}
+let s:preview_buffers = {}
 let s:preview_window = s:null
 
 " TODO testing scenarios (currently blocked by editor version)
@@ -21,39 +21,41 @@ let s:preview_window = s:null
 "   - new buffers bloat
 "   - bouncing
 "   - buffers with existing swaps
-fu! esearch#preview#start() abort
-  let filename = esearch#out#win#filename()
+fu! esearch#preview#start(filename, line) abort
+  if !filereadable(a:filename)
+    return 0
+  endif
 
-  if getfsize(filename) > 50 * 1024
-    return s:using_readlines_strategy(filename)
+  if getfsize(a:filename) > 50 * 1024
+    return s:using_readlines_strategy(a:filename, a:line)
   else
-    return s:using_edit_strategy(filename)
+    return s:using_edit_strategy(a:filename, a:line)
   endif
 endfu
 
-fu! esearch#preview#is_available() abort
-  return has('nvim') && exists('*nvim_open_win')
-endfu
-
-fu! s:using_readlines_strategy(filename) abort
+fu! s:using_readlines_strategy(filename, line) abort
   let filename = a:filename
+  let line = a:line
   let [width, height] = [120, 11]
 
   let lines = readfile(filename)
+  let search_window = bufwinnr(bufnr('%'))
   let preview_buffer = s:create_buffer(filename, 1)
 
   try
-    call s:set_context_lines(preview_buffer, lines, height)
+    call s:set_context_lines(preview_buffer, lines, height, a:line)
     call s:close_preview_window()
-    let s:preview_window = s:open_preview_window(preview_buffer.id, width, height)
+    let s:preview_window = s:open_preview_window(preview_buffer, width, height)
     call s:setup_pseudo_file_appearance(filename, preview_buffer, s:preview_window)
     call s:jump_to_window(s:preview_window.number)
+    call s:reshape_preview_window(line, height)
     call s:setup_autoclose_events()
   catch
     call s:close_preview_window()
     echoerr v:exception
   finally
     let preview_buffer.newly_created = 0
+    call s:jump_to_window(search_window)
   endtry
 endfu
 
@@ -68,10 +70,9 @@ fu! s:setup_pseudo_file_appearance(filename, preview_buffer, preview_window) abo
   endif
 endfu
 
-fu! s:set_context_lines(preview_buffer, lines, height) abort
+fu! s:set_context_lines(preview_buffer, lines, height, line) abort
   let lines = a:lines
-  let line_in_file = esearch#out#win#line_in_file()
-  let column_in_file = esearch#out#win#column_in_file()
+  let line = a:line
 
   let lines_size = len(lines)
 
@@ -80,21 +81,21 @@ fu! s:set_context_lines(preview_buffer, lines, height) abort
     " File smallar then a:height
     let from = 0
     let to = lines_size
-    let line_with_match = line_in_file - 1
-  elseif lines_size - line_in_file < a:height / 2
+    let line_with_match = line - 1
+  elseif lines_size - line < a:height / 2
     " closer to the end then half of the height
     let from = lines_size - a:height
     let to = lines_size
-    let line_with_match = line_in_file - from - 1
-  elseif line_in_file  < a:height / 2
+    let line_with_match = line - from - 1
+  elseif line  < a:height / 2
     " closer to the beginning then half of the height
     let from =  0
     let to = a:height
-    let line_with_match = line_in_file-1
+    let line_with_match = line-1
   else
     " Enough of room up and down
-    let from =  line_in_file - a:height / 2 - 1
-    let to = line_in_file + a:height / 2
+    let from =  line - a:height / 2 - 1
+    let to = line + a:height / 2
     let line_with_match = a:height / 2
   endif
 
@@ -116,10 +117,9 @@ fu! s:set_context_lines(preview_buffer, lines, height) abort
   call assert_equal(len(context_lines),  a:height) " TODO remove when tests are ready
 endfu
 
-fu! s:using_edit_strategy(filename) abort
+fu! s:using_edit_strategy(filename, line) abort
   let filename = a:filename
-  let line_in_file = esearch#out#win#line_in_file()
-  let column_in_file = esearch#out#win#column_in_file()
+  let line = a:line
 
   let search_window = bufwinnr(bufnr('%'))
   let preview_buffer = s:create_buffer(filename, 0)
@@ -128,7 +128,7 @@ fu! s:using_edit_strategy(filename) abort
 
   try
     call s:close_preview_window()
-    let s:preview_window = s:open_preview_window(preview_buffer.id, width, height)
+    let s:preview_window = s:open_preview_window(preview_buffer, width, height)
     if preview_buffer.newly_created
       call s:save_options(preview_buffer)
     endif
@@ -136,8 +136,8 @@ fu! s:using_edit_strategy(filename) abort
     call s:jump_to_window(s:preview_window.number)
     call s:edit_file(filename, preview_buffer)
     call s:setup_edited_file_highlight()
-    call s:setup_matching_line_sign(line_in_file)
-    call s:reshape_preview_window(line_in_file, column_in_file, height)
+    call s:setup_matching_line_sign(line)
+    call s:reshape_preview_window(line, height)
     call s:setup_on_user_opens_buffer_events()
     call s:setup_autoclose_events()
   catch
@@ -150,9 +150,7 @@ fu! s:using_edit_strategy(filename) abort
 endfu
 
 fu! s:save_options(preview_buffer) abort
-  " let a:preview_buffer.guard.winhighlight = nvim_win_get_option(s:preview_window.id, 'winhighlight')
   let a:preview_buffer.guard.swapfile = !!nvim_buf_get_option(a:preview_buffer.id, 'swapfile')
-  " let a:preview_buffer.guard.signcolumn = nvim_win_get_option(s:preview_window.id, 'signcolumn')
 endfu
 
 fu! s:setup_on_user_opens_buffer_events() abort
@@ -166,7 +164,7 @@ fu! s:setup_autoclose_events() abort
   exe 'au ' . s:events . ' * ++once call s:close_preview_window()'
 endfu
 
-fu! s:setup_matching_line_sign(line_in_file) abort
+fu! s:setup_matching_line_sign(line) abort
   if empty(sign_getdefined(s:sign_name))
     call sign_define(s:sign_name, {'text': '->'})
   endif
@@ -176,28 +174,29 @@ fu! s:setup_matching_line_sign(line_in_file) abort
         \ s:sign_group,
         \ s:sign_name,
         \ bufnr('%'),
-        \ {'lnum': a:line_in_file})
+        \ {'lnum': a:line})
 endfu
 
-" Internal winrestview() has a lot of side effects so s:reshape_preview_window
+" Builtin winrestview() has a lot of side effects so s:reshape_preview_window
 " should be invoken as later as possible
-fu! s:reshape_preview_window(line_in_file, column_in_file, height) abort
+fu! s:reshape_preview_window(line, height) abort
   let lines_size = line('$')
   exe 'noautocmd keepjumps resize '. a:height
+  resize 10
 
   if lines_size < a:height
-    return cursor(a:line_in_file, a:column_in_file)
+    return cursor(a:line, 0)
   endif
 
   " literally what :help scrolloff does, but without dealing with options
-  if lines_size - a:line_in_file < a:height
+  if lines_size - a:line < a:height
     let topline = lines_size - a:height
   else
-    let topline = a:line_in_file - (a:height / 2)
+    let topline = a:line - (a:height / 2)
   endif
   noautocmd keepjumps call winrestview({
-        \ 'lnum': a:line_in_file,
-        \ 'col': a:column_in_file,
+        \ 'lnum': a:line,
+        \ 'col': 1,
         \ 'topline': topline,
         \ })
 endfu
@@ -215,14 +214,16 @@ fu! s:open_preview_window(preview_buffer, width, height) abort
   else
     let row = (getpos('.')[1] - line('w0') + 1)
   endif
-  let id = nvim_open_win(a:preview_buffer, 0, {
+
+  let id = nvim_open_win(a:preview_buffer.id, 0, {
         \ 'width':     a:width,
         \ 'height':    a:height,
         \ 'focusable': v:false,
         \ 'row':       row,
         \ 'col':       max([5, wincol() - 1]),
-        \'relative':   'win',
+        \ 'relative':  'win',
         \})
+
   let data = {'id': id, 'number': win_id2win(id), 'guard': {}}
   let data.guard.winhighlight = nvim_win_get_option(id, 'winhighlight')
   let data.guard.signcolumn = nvim_win_get_option(id, 'signcolumn')
@@ -254,21 +255,23 @@ endfu
 fu! s:make_preview_buffer_regular() abort
   let current_filename = expand('%:p')
 
-  if !has_key(s:preview_buffers_registry, current_filename)
+  if !has_key(s:preview_buffers, current_filename)
     " execute once guard
     return
   endif
 
-  let preview_buffer = s:preview_buffers_registry[current_filename]
+  let preview_buffer = s:preview_buffers[current_filename]
   " let &l:winhighlight = preview_buffer.guard.winhighlight
   " let &l:signcolumn = preview_buffer.guard.signcolumn
   try
-    let &l:swapfile = preview_buffer.guard.swapfile
+    if !empty(preview_buffer.guard)
+      let &l:swapfile = preview_buffer.guard.swapfile
+    endif
   catch /:E325:/
     " User is already prompted about existing swap at the moment. Suppress.
     " Occurs when preview is opened and :new command is executed
   finally
-    call remove(s:preview_buffers_registry, current_filename)
+    call remove(s:preview_buffers, current_filename)
   endtry
 
   " prevent other events to handle the buffer again
@@ -276,16 +279,14 @@ fu! s:make_preview_buffer_regular() abort
 endfu
 
 fu! s:create_buffer(filename, disposable) abort
-  " if has_key(s:preview_buffers_registry, a:filename)
-  if bufexists(a:filename)
-    let s:preview_buffers_registry[a:filename] = {
-          \ 'id': bufnr('^' . a:filename . '$'),
-          \ 'filename': a:filename,
-          \ 'newly_created': 0,
-          \ 'is_opened': 0,
-          \ 'guard': {},
-          \ }
-    return s:preview_buffers_registry[a:filename]
+  if has_key(s:preview_buffers, a:filename)
+    if bufexists(a:filename)
+      return s:preview_buffers[a:filename]
+    else
+      " buffer is known as a preview, but it was removed using :bwipeout or the
+      " similar command
+      call remove(s:preview_buffers, a:filename)
+    endif
   endif
 
   if a:disposable
@@ -294,21 +295,21 @@ fu! s:create_buffer(filename, disposable) abort
     let id = nvim_create_buf(1, 0)
   endif
 
-  let s:preview_buffers_registry[a:filename] = {
-        \ 'id': id,
-        \ 'filename': a:filename,
+  let s:preview_buffers[a:filename] = {
+        \ 'id':            id,
+        \ 'filename':      a:filename,
         \ 'newly_created': 1,
-        \ 'is_opened': 0,
-        \ 'guard': {},
+        \ 'is_opened':     0,
+        \ 'guard':         {},
         \ }
-  return s:preview_buffers_registry[a:filename]
+  return s:preview_buffers[a:filename]
 endfu
 
 fu! s:close_preview_window() abort
   if s:preview_window isnot# s:null
     call nvim_win_set_option(s:preview_window.id, 'winhighlight', s:preview_window.guard.winhighlight)
     call nvim_win_set_option(s:preview_window.id, 'signcolumn', s:preview_window.guard.signcolumn)
-    exe s:preview_window.number . 'close'
+    call nvim_win_close(s:preview_window.id, 1)
     let s:preview_window = s:null
   endif
 

--- a/autoload/esearch/preview.vim
+++ b/autoload/esearch/preview.vim
@@ -47,7 +47,7 @@ fu! s:using_readlines_strategy(filename) abort
     call s:close_preview_window()
     let s:preview_window = s:open_preview_window(preview_buffer.id, width, height)
     call s:setup_pseudo_file_appearance(filename, preview_buffer, s:preview_window)
-    call s:goto_window(s:preview_window.number)
+    call s:jump_to_window(s:preview_window.number)
     call s:setup_autoclose_events()
   catch
     call s:close_preview_window()
@@ -133,7 +133,7 @@ fu! s:using_edit_strategy(filename) abort
       call s:save_options(preview_buffer)
     endif
 
-    call s:goto_window(s:preview_window.number)
+    call s:jump_to_window(s:preview_window.number)
     call s:edit_file(filename, preview_buffer)
     call s:setup_edited_file_highlight()
     call s:setup_matching_line_sign(line_in_file)
@@ -145,7 +145,7 @@ fu! s:using_edit_strategy(filename) abort
     echoerr v:exception
   finally
     let preview_buffer.newly_created = 0
-    call s:goto_window(search_window)
+    call s:jump_to_window(search_window)
   endtry
 endfu
 
@@ -247,7 +247,7 @@ fu! s:edit_file(filename, preview_buffer) abort
   return 0
 endfu
 
-fu! s:goto_window(window) abort
+fu! s:jump_to_window(window) abort
   noautocmd keepjumps exe a:window . 'wincmd w'
 endfu
 

--- a/spec/lib/debug_spec.rb
+++ b/spec/lib/debug_spec.rb
@@ -8,7 +8,7 @@ describe Debug do
 
   let(:test_file) { file(%w[line1 line2]) }
   let(:log_file) { file("log entry1\nlog entry2") }
-  let!(:testing_directory) { directory([test_file, log_file]).persist! }
+  let!(:test_directory) { directory([test_file, log_file]).persist! }
 
   subject(:debug) { described_class }
 
@@ -116,10 +116,14 @@ describe Debug do
 
   describe '.working_directories' do
     let(:expected) do
-      {'$PWD' => Configuration.root, 'getcwd()' => testing_directory.path}
+      {
+        '$PWD' => Configuration.root,
+        'getcwd()' => test_directory.path,
+        'cwd_content' => test_directory.files.map { |f| f.path.basename.to_s }
+      }
     end
 
-    before { esearch.cd! testing_directory }
+    before { esearch.cd! test_directory }
 
     it { expect(debug.working_directories).to match(expected) }
   end

--- a/spec/lib/debug_spec.rb
+++ b/spec/lib/debug_spec.rb
@@ -117,8 +117,8 @@ describe Debug do
   describe '.working_directories' do
     let(:expected) do
       {
-        '$PWD' => Configuration.root,
-        'getcwd()' => test_directory.path,
+        '$PWD'        => Configuration.root,
+        'getcwd()'    => test_directory.path,
         'cwd_content' => test_directory.files.map { |f| f.path.basename.to_s }
       }
     end

--- a/spec/plugin/window/preview_spec.rb
+++ b/spec/plugin/window/preview_spec.rb
@@ -8,7 +8,7 @@ describe 'esearch#preview' do
   include Helpers::ReportEditorStateOnError
   include VimlValue::SerializationHelpers
 
-  # TODO extra testing scenarios (currently blocked by editor version)
+  # TODO: extra testing scenarios (currently blocked by editor version)
   #   - file with a name required to be escaped
   #   - new buffers bloat
 
@@ -60,7 +60,7 @@ describe 'esearch#preview' do
         swap_file.unlink
       end
 
-      it "handles buffer opened staying in the current window" do
+      it 'handles buffer opened staying in the current window' do
         expect { editor.send_keys 'p' }
           .to change { window_handles.count }
           .by(1)
@@ -73,7 +73,7 @@ describe 'esearch#preview' do
 
       # regression bug caused by raising error on nvim_open_win after
       # specifying a buffer with existing swap that was already opened
-      it "handles previously opened buffer" do
+      it 'handles previously opened buffer' do
         2.times do
           expect { editor.send_keys 'p' }
             .to change { window_handles.count }

--- a/spec/plugin/window/preview_spec.rb
+++ b/spec/plugin/window/preview_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'esearch#preview' do
+  include Helpers::FileSystem
+  include Helpers::Output
+  include Helpers::ReportEditorStateOnError
+  include VimlValue::SerializationHelpers
+
+  before  { esearch.configure(root_markers: []) }
+
+  let!(:test_directory) { directory(files).persist! }
+
+  let(:files) do
+    [file('aaa', 'from.txt')]
+  end
+
+  describe 'neovim', :neovim do
+    around(Configuration.vimrunner_switch_to_neovim_callback_scope) { |e| use_nvim(&e) }
+    before do
+      esearch.configure!(regex: 1, backend: 'system', adapter: 'ag', 'out': 'win', root_markers: [])
+    end
+    after { esearch.cleanup! }
+    include_context 'report editor state on error'
+
+    before do
+      esearch.cd! test_directory
+      esearch.search!('a')
+      expect { editor.press! 'p' }
+        .to change { editor.windows_list.count }
+        .by(1)
+      expect(editor.map_windows_options('winhighlight')).to contain_exactly('', '', 'Normal:NormalFloat')
+    end
+
+    it do
+      expect { editor.press! 'l' } .to change { editor.windows_list.count } .by(-1)
+      expect(editor.map_windows_options('winhighlight')).to contain_exactly('', '')
+    end
+
+    shared_examples 'silent open' do |key|
+      it do
+        expect { editor.send_keys key }
+          .to not_change { editor.windows_list.count }
+          .and not_to_change { editor.current_buffer_name }
+        expect(editor.map_windows_options('winhighlight')).to all eq('')
+        editor.locate_buffer! files.first.path
+        expect(editor.lines.to_a).to eq(files.first.lines)
+      end
+    end
+
+    shared_examples 'non-silent open' do |key|
+      it do
+        expect { editor.send_keys key }.not_to change { editor.windows_list.count }
+        expect(editor.map_windows_options('winhighlight')).to all eq('')
+        expect(editor.current_buffer_name).to eq(files.first.path.to_s)
+        expect(editor.lines.to_a).to eq(files.first.lines)
+      end
+    end
+
+    it do
+      expect { editor.send_keys :enter }.to change { editor.windows_list.count }.by(-1)
+      expect(editor.map_windows_options('winhighlight')).to all eq('')
+      expect(editor.current_buffer_name).to eq(files.first.path.to_s)
+      expect(editor.lines.to_a).to eq(files.first.lines)
+    end
+
+    it_behaves_like 'silent open', 'T'
+    it_behaves_like 'silent open', 'S'
+    it_behaves_like 'silent open', 'O'
+
+    it_behaves_like 'non-silent open', 't'
+    it_behaves_like 'non-silent open', 's'
+    it_behaves_like 'non-silent open', 'o'
+
+    context 'reset winhl' do
+      it do
+        expect { editor.send_keys 'S', 'S' }
+          .to change { editor.windows_list.count }.by(1)
+          .and not_to_change { editor.current_buffer_name }
+        expect(editor.map_windows_options('winhighlight')).to all eq('')
+        editor.locate_buffer! files.first.path
+        expect(editor.lines.to_a).to eq(files.first.lines)
+      end
+    end
+  end
+end

--- a/spec/plugin/window/preview_spec.rb
+++ b/spec/plugin/window/preview_spec.rb
@@ -4,83 +4,116 @@ require 'spec_helper'
 
 describe 'esearch#preview' do
   include Helpers::FileSystem
-  include Helpers::Output
+  include Helpers::Preview
   include Helpers::ReportEditorStateOnError
   include VimlValue::SerializationHelpers
 
-  before  { esearch.configure(root_markers: []) }
-
-  let!(:test_directory) { directory(files).persist! }
-
-  let(:files) do
-    [file('aaa', 'from.txt')]
-  end
-
   describe 'neovim', :neovim do
+    let(:test_file) { file('aaa', 'from.txt') }
+    let!(:test_directory) { directory([test_file]).persist! }
+
     around(Configuration.vimrunner_switch_to_neovim_callback_scope) { |e| use_nvim(&e) }
     before do
       esearch.configure!(regex: 1, backend: 'system', adapter: 'ag', 'out': 'win', root_markers: [])
-    end
-    after { esearch.cleanup! }
-    include_context 'report editor state on error'
-
-    before do
       esearch.cd! test_directory
       esearch.search!('a')
-      expect { editor.press! 'p' }
-        .to change { editor.windows_list.count }
+      expect { editor.send_keys 'p' }
+        .to change { window_handles.count }
         .by(1)
-      expect(editor.map_windows_options('winhighlight')).to contain_exactly('', '', 'Normal:NormalFloat')
+      expect(window_local_highlights[..-2]).to all eq(default_highlight)
+      expect(window_local_highlights.last).to eq('Normal:NormalFloat')
     end
+    after { esearch.cleanup! }
 
-    it do
-      expect { editor.press! 'l' } .to change { editor.windows_list.count } .by(-1)
-      expect(editor.map_windows_options('winhighlight')).to contain_exactly('', '')
-    end
+    include_context 'report editor state on error'
 
-    shared_examples 'silent open' do |key|
-      it do
-        expect { editor.send_keys key }
-          .to not_change { editor.windows_list.count }
-          .and not_to_change { editor.current_buffer_name }
-        expect(editor.map_windows_options('winhighlight')).to all eq('')
-        editor.locate_buffer! files.first.path
-        expect(editor.lines.to_a).to eq(files.first.lines)
+    shared_context 'verify test file content is not modified after a testcase' do
+      after do
+        # weird regression bug caused by unknown magic with vim's autocommands
+        editor.locate_buffer! test_file.path
+        expect(editor.lines.to_a).to eq(test_file.lines)
       end
     end
 
-    shared_examples 'non-silent open' do |key|
-      it do
-        expect { editor.send_keys key }.not_to change { editor.windows_list.count }
-        expect(editor.map_windows_options('winhighlight')).to all eq('')
-        expect(editor.current_buffer_name).to eq(files.first.path.to_s)
-        expect(editor.lines.to_a).to eq(files.first.lines)
+    describe 'closing on cursor moved' do
+      it 'closes window on regular movement' do
+        expect { editor.send_keys 'l' }
+          .to change { window_handles.count }
+          .by(-1)
+        expect(window_local_highlights).to all eq(default_highlight)
       end
     end
 
-    it do
-      expect { editor.send_keys :enter }.to change { editor.windows_list.count }.by(-1)
-      expect(editor.map_windows_options('winhighlight')).to all eq('')
-      expect(editor.current_buffer_name).to eq(files.first.path.to_s)
-      expect(editor.lines.to_a).to eq(files.first.lines)
+    describe 'closing on opening' do
+      context 'when opening with staying in the current window' do
+        shared_examples 'open with stayin in the window' do |keys:|
+          include_context 'verify test file content is not modified after a testcase'
+
+          it 'closes preview and resets window-local highlits' do
+            expect { editor.send_keys keys }
+              .to not_change { window_handles.count }
+              .and not_to_change { editor.current_buffer_name }
+            expect(window_local_highlights).to all eq(default_highlight)
+          end
+        end
+
+        it_behaves_like 'open with stayin in the window', keys: 'T'
+        it_behaves_like 'open with stayin in the window', keys: 'S'
+        it_behaves_like 'open with stayin in the window', keys: 'O'
+      end
+
+      context 'when opening with jumping to an opened window' do
+        shared_examples 'open with jumping to the opened file' do |keys:|
+          include_context 'verify test file content is not modified after a testcase'
+
+          it 'closes preview and resets window-local highlits' do
+            expect { editor.send_keys key }
+              .to not_change { window_handles.count }
+              .and change { editor.current_buffer_name }.to(test_file.path.to_s)
+            expect(window_local_highlights).to all eq(default_highlight)
+          end
+        end
+
+        it_behaves_like 'open with jumping to the opened file', keys: 't'
+        it_behaves_like 'open with jumping to the opened file', keys: 's'
+        it_behaves_like 'open with jumping to the opened file', keys: 'o'
+      end
+
+      context 'when opening in the current window' do
+        include_context 'verify test file content is not modified after a testcase'
+
+        it 'closes preview and resets window-local highlits' do
+          expect { editor.send_keys :enter }
+            .to change { window_handles.count }.by(-1)
+                                               .and change { editor.current_buffer_name }
+            .to(test_file.path.to_s)
+          expect(window_local_highlights).to all eq(default_highlight)
+        end
+      end
     end
 
-    it_behaves_like 'silent open', 'T'
-    it_behaves_like 'silent open', 'S'
-    it_behaves_like 'silent open', 'O'
+    context 'describe keypress' do
+      context 'bouncing split with staying in the current window' do
+        include_context 'verify test file content is not modified after a testcase'
 
-    it_behaves_like 'non-silent open', 't'
-    it_behaves_like 'non-silent open', 's'
-    it_behaves_like 'non-silent open', 'o'
+        # regression bug when the second opened buffer had incorrect
+        # winhighlight
+        it 'resets window-local highlight for all opened windows' do
+          expect { editor.send_keys 'S', 'S' }
+            .to change { window_handles.count }.by(1)
+                                               .and not_to_change { editor.current_buffer_name }
+          expect(window_local_highlights).to all eq(default_highlight)
+        end
+      end
 
-    context 'reset winhl' do
-      it do
-        expect { editor.send_keys 'S', 'S' }
-          .to change { editor.windows_list.count }.by(1)
-          .and not_to_change { editor.current_buffer_name }
-        expect(editor.map_windows_options('winhighlight')).to all eq('')
-        editor.locate_buffer! files.first.path
-        expect(editor.lines.to_a).to eq(files.first.lines)
+      context 'when bouncing opening preview' do
+        it 'keeps only a single preview window opened' do
+          expect { editor.send_keys 'p', 'p' }
+            .to not_change { window_handles.count }
+            .and not_to_change { editor.current_buffer_name }
+          expect(window_local_highlights[..-2]).to all eq(default_highlight)
+          expect(window_local_highlights.last).to eq('Normal:NormalFloat')
+        end
       end
     end
   end

--- a/spec/plugin/window/preview_spec.rb
+++ b/spec/plugin/window/preview_spec.rb
@@ -8,8 +8,9 @@ describe 'esearch#preview' do
   include Helpers::ReportEditorStateOnError
   include VimlValue::SerializationHelpers
 
-  # TODO it's still unknown why neovim don't want to create swap files on
-  # during tests. set swapfile directory=... doesn't work
+  # TODO extra testing scenarios (currently blocked by editor version)
+  #   - file with a name required to be escaped
+  #   - new buffers bloat
 
   describe 'neovim', :neovim do
     let(:search_string) { 'a' }

--- a/spec/support/fixtures/lazy_file.rb
+++ b/spec/support/fixtures/lazy_file.rb
@@ -22,7 +22,7 @@ class Fixtures::LazyFile
   end
 
   def path
-    return working_directory.join(relative_path) if working_directory.present?
+    return working_directory.join(relative_path) unless working_directory.nil?
 
     Pathname(relative_path)
   end

--- a/spec/support/fixtures/lazy_file.rb
+++ b/spec/support/fixtures/lazy_file.rb
@@ -22,7 +22,9 @@ class Fixtures::LazyFile
   end
 
   def path
-    working_directory.join(relative_path)
+    return working_directory.join(relative_path) if working_directory.present?
+
+    Pathname(relative_path)
   end
 
   def relative_path

--- a/spec/support/fixtures/lazy_file.rb
+++ b/spec/support/fixtures/lazy_file.rb
@@ -22,9 +22,10 @@ class Fixtures::LazyFile
   end
 
   def path
-    return working_directory.join(relative_path) unless working_directory.nil?
+    working_directory.join(relative_path)
+    # return working_directory.join(relative_path) unless working_directory.nil?
 
-    Pathname(relative_path)
+    # Pathname(relative_path)
   end
 
   def relative_path

--- a/spec/support/helpers/output.rb
+++ b/spec/support/helpers/output.rb
@@ -3,6 +3,9 @@
 module Helpers::Output
   extend RSpec::Matchers::DSL
 
+  define_negated_matcher :not_to_change, :change
+  define_negated_matcher :not_change, :change
+
   def finish_search_in_files(filenames)
     have_search_started
       .and have_search_finished

--- a/spec/support/helpers/output.rb
+++ b/spec/support/helpers/output.rb
@@ -3,9 +3,6 @@
 module Helpers::Output
   extend RSpec::Matchers::DSL
 
-  define_negated_matcher :not_to_change, :change
-  define_negated_matcher :not_change, :change
-
   def finish_search_in_files(filenames)
     have_search_started
       .and have_search_finished

--- a/spec/support/helpers/preview.rb
+++ b/spec/support/helpers/preview.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Helpers::Preview
+  extend RSpec::Matchers::DSL
+
+  define_negated_matcher :not_to_change, :change
+  define_negated_matcher :not_change, :change
+
+  def window_handles
+    editor.echo func('nvim_list_wins')
+  end
+
+  def window_local_highlights
+    map_windows_options('winhighlight')
+  end
+
+  def default_highlight
+    ''
+  end
+
+  def map_windows_options(name)
+    editor.echo func('map', func('nvim_list_wins'), "nvim_win_get_option(v:val, #{name.dump})")
+  end
+end

--- a/spec/support/helpers/preview.rb
+++ b/spec/support/helpers/preview.rb
@@ -21,4 +21,11 @@ module Helpers::Preview
   def map_windows_options(name)
     editor.echo func('map', func('nvim_list_wins'), "nvim_win_get_option(v:val, #{name.dump})")
   end
+
+  def swap_path(file_path)
+    [
+      editor.echo(var('&directory')),
+      [file_path.relative_path_from(editor.cwd).to_s.gsub('/', '%'), '.swp'].join
+    ].join('/')
+  end
 end

--- a/spec/support/lib/debug.rb
+++ b/spec/support/lib/debug.rb
@@ -27,9 +27,7 @@ module Debug
   def working_directories
     paths = reader.echo([var('$PWD'), func('getcwd')]).map { |p| Pathname(p) }
     result = ['$PWD', 'getcwd()'].zip(paths).to_h
-    if File.directory?(result['getcwd()'])
-      result['cwd_content'] = Dir.entries(result['getcwd()']) - ['.', '..']
-    end
+    result['cwd_content'] = Dir.entries(result['getcwd()']) - ['.', '..'] if File.directory?(result['getcwd()'])
     result
   end
 

--- a/spec/support/lib/debug.rb
+++ b/spec/support/lib/debug.rb
@@ -26,7 +26,11 @@ module Debug
 
   def working_directories
     paths = reader.echo([var('$PWD'), func('getcwd')]).map { |p| Pathname(p) }
-    ['$PWD', 'getcwd()'].zip(paths).to_h
+    result = ['$PWD', 'getcwd()'].zip(paths).to_h
+    if File.directory?(result['getcwd()'])
+      result['cwd_content'] = Dir.entries(result['getcwd()']) - ['.', '..']
+    end
+    result
   end
 
   def user_autocommands

--- a/spec/support/lib/editor.rb
+++ b/spec/support/lib/editor.rb
@@ -124,6 +124,18 @@ class Editor
     echo(func('search', modifiers + escape_regexp(text), 'w'))
   end
 
+  def windows_list
+    editor.echo func('nvim_list_wins')
+  end
+
+  def get_last_window_optoin(name)
+    editor.echo func('nvim_win_get_option', func('max', func('nvim_list_wins')), name)
+  end
+
+  def map_windows_options(name)
+    editor.echo func('map', func('nvim_list_wins'), "nvim_win_get_option(v:val, #{name.dump})")
+  end
+
   # using vim builtin rules
   def escape_filename(text)
     # NOTE: only leading [+>] are escaped (according to builtin :h fnameescape).

--- a/spec/support/lib/editor.rb
+++ b/spec/support/lib/editor.rb
@@ -266,6 +266,10 @@ class Editor
     echo func('get', var('w:'), 'quickfix_title', '')
   end
 
+  def cwd
+    echo func('getcwd')
+  end
+
   def trigger_cursor_moved_event!
     press!('<Esc>lh')
   end
@@ -323,6 +327,12 @@ class Editor
   def send_keys_separately(*keyboard_keys)
     editor.command('let &undolevels=&undolevels')
     keyboard_keys.map { |key| send_keys(key, split_undo_entry: false) }
+  end
+
+  # Allows interfacing with prompts etc. where other functions doesn't work
+  def raw_send_keys(*keys)
+    handle_state_change!
+    keys.each { |key| vim.type(key) }
   end
 
   # imitation of command inputter by a user

--- a/spec/support/lib/editor.rb
+++ b/spec/support/lib/editor.rb
@@ -124,18 +124,6 @@ class Editor
     echo(func('search', modifiers + escape_regexp(text), 'w'))
   end
 
-  def windows_list
-    editor.echo func('nvim_list_wins')
-  end
-
-  def get_last_window_optoin(name)
-    editor.echo func('nvim_win_get_option', func('max', func('nvim_list_wins')), name)
-  end
-
-  def map_windows_options(name)
-    editor.echo func('map', func('nvim_list_wins'), "nvim_win_get_option(v:val, #{name.dump})")
-  end
-
   # using vim builtin rules
   def escape_filename(text)
     # NOTE: only leading [+>] are escaped (according to builtin :h fnameescape).

--- a/spec/support/viml/vimrc.vim
+++ b/spec/support/viml/vimrc.vim
@@ -5,8 +5,9 @@ set nocompatible
 filetype plugin on
 filetype indent on
 syntax on
+set swapfile directory=/tmp
+set updatecount=1
 
-set noswapfile nobackup
 
 " remove default ~/.vim directories to avoid loading plugins
 set runtimepath-=~/.vim

--- a/spec/support/viml/vimrc.vim
+++ b/spec/support/viml/vimrc.vim
@@ -5,8 +5,7 @@ set nocompatible
 filetype plugin on
 filetype indent on
 syntax on
-set swapfile directory=/tmp
-set updatecount=1
+set nobackup swapfile directory=/tmp updatecount=1
 
 
 " remove default ~/.vim directories to avoid loading plugins


### PR DESCRIPTION
- Fix preview feature coverage
- Implement dumping of getcwd content on test failure
- Fix bugs related to swapfiles and buggy window-local highlights unloading
- Implement experimental API to use customized previews handling:
```viml
 au Filetype esearch let b:preview = esearch#debounce#trailing(b:esearch.preview, 1000)
       \ | au CursorMoved <buffer> call b:preview.invoke()
```