### PR TITLE
FIx cwd handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,7 @@ jobs:
     #   services: docker
     #   os: linux
     - name: 'Acceptance tests of #backend#vim8 with #viml render and #legacy parser'
-      script: bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag vim8 --tag ~render:lua --tag
+      script: bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag vim8 --tag ~render:lua
       os: linux
     - name: 'Acceptance tests of #backend#vim8 with #lua render'
       script: bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag vim8 --tag ~render:viml

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,11 +130,8 @@ jobs:
     #   env: NVIM_GUI=0 DOCKER_BUILD=1
     #   services: docker
     #   os: linux
-    - name: 'Acceptance tests of #backend#vim8 with #viml render and #getqflist parser'
-      script: bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag vim8 --tag ~render:lua --tag ~parse:legacy
-      os: linux
     - name: 'Acceptance tests of #backend#vim8 with #viml render and #legacy parser'
-      script: bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag vim8 --tag ~render:lua --tag ~parse:getqflist
+      script: bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag vim8 --tag ~render:lua --tag
       os: linux
     - name: 'Acceptance tests of #backend#vim8 with #lua render'
       script: bundle exec parallel_split_test spec/plugin/backend_spec.rb --tag vim8 --tag ~render:viml

--- a/autoload/esearch.vim
+++ b/autoload/esearch.vim
@@ -37,9 +37,10 @@ fu! esearch#init(...) abort
   let requires_pty = esearch#adapter#{esearch.adapter}#requires_pty()
   let esearch = extend(esearch, {
         \ 'title': s:title(esearch, pattern),
-        \ 'request': esearch#backend#{esearch.backend}#init(esearch.adapter, shell_cmd, requires_pty),
         \}, 'force')
 
+  let esearch.request = esearch#backend#{esearch.backend}#init(
+        \ esearch.cwd, esearch.adapter, shell_cmd, requires_pty)
   let esearch.parse = esearch#adapter#parse#funcref()
 
   call esearch#out#{esearch.out}#init(esearch)
@@ -62,17 +63,6 @@ fu! s:new(configuration) abort
   endif
   if !has_key(configuration, 'escaped_cwd')
     let configuration.escaped_cwd = fnameescape(configuration.cwd)
-  endif
-
-  if g:esearch#has#lua
-    let configuration.lua_cwd_prefix =
-          \ luaeval("'^' .. _A:gsub('([^%w])', '%%%1') .. '%/'",
-          \ configuration.cwd)
-  endif
-  if g:esearch#has#windows
-    let configuration.cwd_prefix = substitute(configuration.cwd, '\\', '\\\\', 'g').'\\'
-  else
-    let configuration.cwd_prefix = configuration.cwd . '/'
   endif
 
   return configuration

--- a/autoload/esearch/adapter/ag_like.vim
+++ b/autoload/esearch/adapter/ag_like.vim
@@ -2,10 +2,8 @@ let esearch#adapter#ag_like#format = '^\(.\{-}\)\:\(\d\{-}\)\:\(.\{-}\)$'
 
 fu! esearch#adapter#ag_like#joined_paths(esearch) abort
   if empty(a:esearch.paths)
-    let joined_paths = a:esearch.cwd
-  else
-    let joined_paths = esearch#shell#fnamesescape_and_join(a:esearch.paths, a:esearch.metadata)
+    return ''
   endif
 
-  return joined_paths
+  return esearch#shell#fnamesescape_and_join(a:esearch.paths, a:esearch.metadata)
 endfu

--- a/autoload/esearch/adapter/grep.vim
+++ b/autoload/esearch/adapter/grep.vim
@@ -80,7 +80,7 @@ fu! esearch#adapter#grep#cmd(esearch, pattern, escape) abort
   " return g:esearch#adapter#grep#bin.' '.r.' '.c.' '.w.' -r --line-number --exclude-dir=.{git,svn,hg} ' .
   return g:esearch#adapter#grep#bin.' '.r.' '.c.' '.w.' -H -I -r -n '.options.show_line_numbers.' '.options.exclude_dirs.' '.
         \ g:esearch#adapter#grep#options . ' -- ' .
-        \ a:escape(a:pattern) . ' ' . joined_paths
+        \ a:escape(a:pattern) . ' ' . (empty(joined_paths) ? '.' : joined_paths)
 endfu
 
 fu! esearch#adapter#grep#requires_pty() abort

--- a/autoload/esearch/adapter/grep_like.vim
+++ b/autoload/esearch/adapter/grep_like.vim
@@ -2,16 +2,14 @@ let esearch#adapter#grep_like#multiple_files_Search_format = '^\(.\{-}\)\:\(\d\{
 
 fu! esearch#adapter#grep_like#joined_paths(esearch) abort
   if empty(a:esearch.paths)
-    let joined_paths = a:esearch.cwd
-  else
-    let paths = deepcopy(a:esearch.paths)
-    let escaped = []
-    for i in range(0, len(paths)-1)
-      call add(escaped, fnameescape(paths[i]))
-    endfor
-
-    let joined_paths = join(escaped, ' ')
+    return ''
   endif
 
-  return joined_paths
+  let paths = deepcopy(a:esearch.paths)
+  let escaped = []
+  for i in range(0, len(paths)-1)
+    call add(escaped, fnameescape(paths[i]))
+  endfor
+
+  return join(escaped, ' ')
 endfu

--- a/autoload/esearch/adapter/parse.vim
+++ b/autoload/esearch/adapter/parse.vim
@@ -1,6 +1,3 @@
-if !exists('g:esearch_out_win_parse_using_getqflist')
-  let g:esearch_out_win_parse_using_getqflist = g:esearch#has#getqflist_lines
-endif
 if !exists('g:esearch_out_win_render_using_lua')
   let g:esearch_out_win_render_using_lua = g:esearch#has#lua
 endif
@@ -9,8 +6,6 @@ fu! esearch#adapter#parse#funcref() abort
   if g:esearch_out_win_render_using_lua
     " TODO move lua chunks to separate files to improve reusability
     return esearch#adapter#parse#lua#funcref()
-  elseif g:esearch_out_win_parse_using_getqflist
-    return esearch#adapter#parse#viml#getqflines_funcref()
   else
     return esearch#adapter#parse#viml#legacy_funcref()
   endif

--- a/autoload/esearch/adapter/parse/lua.vim
+++ b/autoload/esearch/adapter/parse/lua.vim
@@ -41,7 +41,10 @@ function parse_line(line)
       ['\"'] = '\"',
       ['\033'] = string.char(27)
     }
-    return filename:gsub('\\(.)', controls), line, text
+    filename = filename:gsub('\\(.)', controls)
+    if filereadable(filename) then
+      return filename, line, text
+    end
   end
 
   while true do

--- a/autoload/esearch/adapter/parse/lua.vim
+++ b/autoload/esearch/adapter/parse/lua.vim
@@ -8,11 +8,11 @@ endfu
 
 if g:esearch#has#nvim_lua
   fu! esearch#adapter#parse#lua#parse(data, from, to) abort dict
-    return luaeval('parse_lines(_A[1], _A[2])', [a:data[a:from : a:to], self.lua_cwd_prefix])
+    return luaeval('parse_lines(_A[1])', [a:data[a:from : a:to]])
   endfu
 else
   fu! esearch#adapter#parse#lua#parse(data, from, to) abort dict
-    return luaeval('parse_lines(_A[0], _A[1])', [a:data[a:from : a:to], self.lua_cwd_prefix])
+    return luaeval('parse_lines(_A[0])', [a:data[a:from : a:to]])
   endfu
 endif
 
@@ -104,7 +104,7 @@ function fnameescape(path)
   return vim.api.nvim_call_function('fnameescape', {path})
 end
 
-function parse_lines(data, cwd_prefix)
+function parse_lines(data)
   local parsed = {}
   filereadable_cache = {}
 
@@ -119,7 +119,7 @@ function parse_lines(data, cwd_prefix)
 
       if filename ~= nil then
         parsed[#parsed + 1] = {
-          ['filename'] = string.gsub(filename, cwd_prefix, ''),
+          ['filename'] = filename,
           ['lnum']     = lnum,
           ['text']     = text:gsub("[\r\n]", '')
         }
@@ -155,7 +155,7 @@ function fnameescape(path)
   return vim.funcref('fnameescape')(path)
 end
 
-function parse_lines(data, cwd_prefix)
+function parse_lines(data)
   local parsed = vim.list()
   filereadable_cache = {}
 
@@ -171,7 +171,7 @@ function parse_lines(data, cwd_prefix)
 
       if filename ~= nil  then
         parsed:add(vim.dict({
-          ['filename'] = string.gsub(filename, cwd_prefix, ''),
+          ['filename'] = filename,
           ['lnum']     = lnum,
           ['text']     = text:gsub("[\r\n]", '')
         }))

--- a/autoload/esearch/adapter/parse/viml.vim
+++ b/autoload/esearch/adapter/parse/viml.vim
@@ -37,35 +37,38 @@ fu! esearch#adapter#parse#viml#legacy(data, from, to) abort dict
 
       let filename = substitute(filename, '\\\([abtnvfr"\\]\|033\)',
             \ '\=g:esearch#adapter#parse#viml#controls[submatch(1)]', 'g')
-      call add(results, {
-            \ 'filename': filename,
-            \ 'lnum':     lnum,
-            \ 'text':     text})
-    else
-      let offset = 0
-      while 1
-        let idx = stridx(line, ':', offset)
+      if filereadable(filename)
+        call add(results, {
+              \ 'filename': filename,
+              \ 'lnum':     lnum,
+              \ 'text':     text})
+        continue
+      endif
+    endif
 
-        if idx < 0
-          break
-        endif
+    let offset = 0
+    while 1
+      let idx = stridx(line, ':', offset)
 
-        let filename = line[0 : idx - 1]
-        let offset = idx + 1
+      if idx < 0
+        break
+      endif
 
-        if filereadable(filename)
-          break
-        end
-      endwhile
+      let filename = line[0 : idx - 1]
+      let offset = idx + 1
 
-      if idx > 0
-        let matches = matchlist(line, '\(\d\+\)[-:]\(.*\)', offset)[1:2]
-        if !empty(matches)
-          call add(results, {
-                \ 'filename': filename,
-                \ 'lnum':     matches[0],
-                \ 'text':     matches[1]})
-        endif
+      if filereadable(filename)
+        break
+      end
+    endwhile
+
+    if idx > 0
+      let matches = matchlist(line, '\(\d\+\)[-:]\(.*\)', offset)[1:2]
+      if !empty(matches)
+        call add(results, {
+              \ 'filename': filename,
+              \ 'lnum':     matches[0],
+              \ 'text':     matches[1]})
       endif
     endif
 

--- a/autoload/esearch/adapter/parse/viml.vim
+++ b/autoload/esearch/adapter/parse/viml.vim
@@ -28,21 +28,19 @@ fu! esearch#adapter#parse#viml#legacy(data, from, to) abort dict
 
     if line[0] ==# '"'
       let res = matchlist(line, '^"\(\%(\\\\\|\\"\|.\)\{-}\)"\:\(\d\{-}\)[-:]\(.*\)$')[1:3]
-      if len(res) != 3
-        let i += 1
-        continue
-      endif
+      if len(res) == 3
+        let [filename, lnum, text] = res
 
-      let [filename, lnum, text] = res
-
-      let filename = substitute(filename, '\\\([abtnvfr"\\]\|033\)',
-            \ '\=g:esearch#adapter#parse#viml#controls[submatch(1)]', 'g')
-      if filereadable(filename)
-        call add(results, {
-              \ 'filename': filename,
-              \ 'lnum':     lnum,
-              \ 'text':     text})
-        continue
+        let filename = substitute(filename, '\\\([abtnvfr"\\]\|033\)',
+              \ '\=g:esearch#adapter#parse#viml#controls[submatch(1)]', 'g')
+        if filereadable(filename)
+          call add(results, {
+                \ 'filename': filename,
+                \ 'lnum':     lnum,
+                \ 'text':     text})
+          let i += 1
+          continue
+        endif
       endif
     endif
 

--- a/autoload/esearch/backend/nvim.vim
+++ b/autoload/esearch/backend/nvim.vim
@@ -7,7 +7,7 @@ endif
 
 let s:NVIM_JOB_IS_INVALID = -3
 
-fu! esearch#backend#nvim#init(adapter, cmd, pty) abort
+fu! esearch#backend#nvim#init(cwd, adapter, cmd, pty) abort
   let request = {
         \ 'internal_job_id': s:incrementable_internal_id,
         \ 'jobstart_args': {
@@ -24,8 +24,9 @@ fu! esearch#backend#nvim#init(adapter, cmd, pty) abort
         \ 'backend':  'nvim',
         \ 'adapter':  a:adapter,
         \ 'command':  a:cmd,
+        \ 'cwd':      a:cwd,
         \ 'data':     [],
-        \ 'intermediate':     '',
+        \ 'intermediate': '',
         \ 'errors':     [],
         \ 'finished': 0,
         \ 'status': 0,
@@ -43,10 +44,16 @@ fu! esearch#backend#nvim#init(adapter, cmd, pty) abort
 endfu
 
 fu! esearch#backend#nvim#run(request) abort
-  let job_id = jobstart(a:request.jobstart_args.cmd, a:request.jobstart_args.opts)
-  let a:request.job_id = job_id
-  call jobclose(job_id, 'stdin')
-  let s:jobs[job_id] = { 'data': [], 'request': a:request }
+  let orignal_cwd = getcwd()
+  exe 'lcd ' . a:request.cwd
+  try
+    let job_id = jobstart(a:request.jobstart_args.cmd, a:request.jobstart_args.opts)
+    let a:request.job_id = job_id
+    call jobclose(job_id, 'stdin')
+    let s:jobs[job_id] = { 'data': [], 'request': a:request }
+  finally
+    exe 'lcd ' . orignal_cwd
+  endtry
 endfu
 
 " TODO encoding

--- a/autoload/esearch/backend/nvim.vim
+++ b/autoload/esearch/backend/nvim.vim
@@ -44,15 +44,14 @@ fu! esearch#backend#nvim#init(cwd, adapter, cmd, pty) abort
 endfu
 
 fu! esearch#backend#nvim#run(request) abort
-  let orignal_cwd = getcwd()
-  exe 'lcd ' . a:request.cwd
+  let original_cwd = esearch#util#lcd(a:request.cwd)
   try
     let job_id = jobstart(a:request.jobstart_args.cmd, a:request.jobstart_args.opts)
     let a:request.job_id = job_id
     call jobclose(job_id, 'stdin')
     let s:jobs[job_id] = { 'data': [], 'request': a:request }
   finally
-    exe 'lcd ' . orignal_cwd
+    call original_cwd.restore()
   endtry
 endfu
 

--- a/autoload/esearch/backend/system.vim
+++ b/autoload/esearch/backend/system.vim
@@ -13,8 +13,7 @@ fu! esearch#backend#system#init(cwd, adapter, cmd, pty) abort
 endfu
 
 fu! esearch#backend#system#run(request) abort
-  let original_cwd = getcwd()
-  exe 'lcd ' . a:request.cwd
+  let original_cwd = esearch#util#lcd(a:request.cwd)
   try
     let a:request.data = split(system(a:request.command), "\n")
     let a:request.status = v:shell_error
@@ -25,7 +24,7 @@ fu! esearch#backend#system#run(request) abort
       redraw!
     endif
   finally
-    exe 'lcd ' . original_cwd
+    call original_cwd.restore()
   endtry
 endfu
 

--- a/autoload/esearch/backend/vim8.vim
+++ b/autoload/esearch/backend/vim8.vim
@@ -55,12 +55,11 @@ endfu
 
 fu! esearch#backend#vim8#run(request) abort
   let s:jobs[a:request.internal_job_id] = { 'data': [], 'request': a:request }
-  let original_cwd = getcwd()
-  exe 'lcd ' . a:request.cwd
+  let original_cwd = esearch#util#lcd(a:request.cwd)
   try
     let a:request.job_id = job_start(a:request.jobstart_args.cmd, a:request.jobstart_args.opts)
   finally
-    exe 'lcd ' . original_cwd
+    call original_cwd.restore()
   endtry
 endfu
 

--- a/autoload/esearch/backend/vim8.vim
+++ b/autoload/esearch/backend/vim8.vim
@@ -13,7 +13,7 @@ endif
 let s:jobs = {}
 let s:id = esearch#itertools#count()
 
-fu! esearch#backend#vim8#init(adapter, cmd, pty) abort
+fu! esearch#backend#vim8#init(cwd, adapter, cmd, pty) abort
   " TODO add 'stoponexit'
   let id = s:id.next()
   let request = {
@@ -37,6 +37,7 @@ fu! esearch#backend#vim8#init(adapter, cmd, pty) abort
         \ 'adapter':  a:adapter,
         \ 'intermediate':  '',
         \ 'command':  a:cmd,
+        \ 'cwd':      a:cwd,
         \ 'data':     [],
         \ 'errors':     [],
         \ 'finished': 0,
@@ -54,7 +55,13 @@ endfu
 
 fu! esearch#backend#vim8#run(request) abort
   let s:jobs[a:request.internal_job_id] = { 'data': [], 'request': a:request }
-  let a:request.job_id = job_start(a:request.jobstart_args.cmd, a:request.jobstart_args.opts)
+  let original_cwd = getcwd()
+  exe 'lcd ' . a:request.cwd
+  try
+    let a:request.job_id = job_start(a:request.jobstart_args.cmd, a:request.jobstart_args.opts)
+  finally
+    exe 'lcd ' . original_cwd
+  endtry
 endfu
 
 " TODO encoding

--- a/autoload/esearch/backend/vimproc.vim
+++ b/autoload/esearch/backend/vimproc.vim
@@ -17,13 +17,14 @@ let s:incrementable_internal_id = 0
 
 " TODO decouple consuming of data from pipe and output updation processes
 
-fu! esearch#backend#vimproc#init(adapter, cmd, pty) abort
+fu! esearch#backend#vimproc#init(cwd, adapter, cmd, pty) abort
   let request = {
         \ 'internal_id': s:incrementable_internal_id,
         \ 'format': '%f:%l:%c:%m,%f:%l:%m',
         \ 'backend': 'vimproc',
         \ 'adapter': a:adapter,
         \ 'command': a:cmd,
+        \ 'cwd': a:cwd,
         \ 'data': [],
         \ 'errors': [],
         \ 'async': 1,
@@ -46,17 +47,24 @@ fu! esearch#backend#vimproc#init(adapter, cmd, pty) abort
 endfu
 
 fu! esearch#backend#vimproc#run(request) abort
-  let pipe = vimproc#popen3(
-        \ vimproc#util#iconv(a:request.command, &encoding, 'char'), a:request.pty)
-  call pipe.stdin.close()
+  let original_cwd = getcwd()
+  exe 'lcd ' . a:request.cwd
+  try
+    let pipe = vimproc#popen3(
+          \ vimproc#util#iconv(a:request.command, &encoding, 'char'), a:request.pty)
+    call pipe.stdin.close()
 
-  let a:request.pipe = pipe
+    let a:request.pipe = pipe
 
-  exe 'aug ESearchVimproc'.a:request.internal_id
-    au!
-    exe 'au CursorMoved * call s:_on_cursor_moved('.a:request.internal_id.')'
-    exe 'au CursorHold  * call s:_on_cursor_hold('. a:request.internal_id.')'
-  aug END
+    " TODO should not be within the adapter
+    exe 'aug ESearchVimproc'.a:request.internal_id
+      au!
+      exe 'au CursorMoved * call s:_on_cursor_moved('.a:request.internal_id.')'
+      exe 'au CursorHold  * call s:_on_cursor_hold('. a:request.internal_id.')'
+    aug END
+  finally
+    exe 'lcd ' . original_cwd
+  endtry
 endfu
 
 fu! esearch#backend#vimproc#escape_cmd(cmd) abort
@@ -167,7 +175,6 @@ fu! esearch#backend#vimproc#init_events() abort
   au BufUnload <buffer>
         \ call esearch#backend#vimproc#abort(str2nr(expand('<abuf>')))
 endfu
-
 
 function! esearch#backend#vimproc#sid() abort
   return maparg('<SID>', 'n')

--- a/autoload/esearch/backend/vimproc.vim
+++ b/autoload/esearch/backend/vimproc.vim
@@ -47,8 +47,7 @@ fu! esearch#backend#vimproc#init(cwd, adapter, cmd, pty) abort
 endfu
 
 fu! esearch#backend#vimproc#run(request) abort
-  let original_cwd = getcwd()
-  exe 'lcd ' . a:request.cwd
+  let original_cwd = esearch#util#lcd(a:request.cwd)
   try
     let pipe = vimproc#popen3(
           \ vimproc#util#iconv(a:request.command, &encoding, 'char'), a:request.pty)
@@ -63,7 +62,7 @@ fu! esearch#backend#vimproc#run(request) abort
       exe 'au CursorHold  * call s:_on_cursor_hold('. a:request.internal_id.')'
     aug END
   finally
-    exe 'lcd ' . original_cwd
+    call original_cwd.restore()
   endtry
 endfu
 

--- a/autoload/esearch/has.vim
+++ b/autoload/esearch/has.vim
@@ -1,5 +1,4 @@
 let g:esearch#has#debounce = has('timers')
-let g:esearch#has#getqflist_lines = has('patch8.0.1031')
 let g:esearch#has#windows = has('win32')
 let g:esearch#has#nvim_add_highlight = exists('*nvim_buf_clear_namespace') && exists('*nvim_buf_add_highlight')
 let g:esearch#has#virtual_cursor_linenr_highlight = !has('nvim') || g:esearch#has#nvim_add_highlight

--- a/autoload/esearch/out/qflist.vim
+++ b/autoload/esearch/out/qflist.vim
@@ -28,7 +28,6 @@ fu! esearch#out#qflist#init(opts) abort
         \ 'data':                [],
         \})
 
-
   call extend(g:esearch_qf.request, {
         \ 'cursor':     0,
         \ 'out_finish':   function('esearch#out#qflist#_is_render_finished')
@@ -85,15 +84,20 @@ fu! esearch#out#qflist#update() abort
       let request.cursor += esearch.batch_size
     endif
 
-    let parsed = esearch.parse(data, from, to)
-
-    if esearch#util#qftype(bufnr('%')) ==# 'qf'
-      let curpos = getcurpos()[1:]
-      noau call setqflist(parsed, 'a')
-      call cursor(curpos)
-    else
-      noau call setqflist(parsed, 'a')
-    endif
+    let original_cwd = esearch#util#lcd(esearch.cwd)
+    try
+      let parsed = esearch.parse(data, from, to)
+      let g:parsed = parsed
+      if esearch#util#qftype(bufnr('%')) ==# 'qf'
+        let curpos = getcurpos()[1:]
+        noau call setqflist(parsed, 'a')
+        call cursor(curpos)
+      else
+        noau call setqflist(parsed, 'a')
+      endif
+    finally
+      call original_cwd.restore()
+    endtry
   endif
 endfu
 

--- a/autoload/esearch/out/win/render/lua.vim
+++ b/autoload/esearch/out/win/render/lua.vim
@@ -21,14 +21,19 @@ endif
 
 if g:esearch#has#nvim_lua
   fu! esearch#out#win#render#lua#do(bufnr, data, from, to, esearch) abort
-    let [files_count, contexts, ctx_ids_map, line_numbers_map, context_by_name] =
-          \ luaeval('esearch_out_win_render_nvim(_A[1], _A[2], _A[3], _A[4], _A[5], _A[6], _A[7])',
-          \ [a:data[a:from : a:to],
-          \ get(a:esearch.paths, 0, ''),
-          \ a:esearch.lua_cwd_prefix,
-          \ a:esearch.contexts[-1],
-          \ a:esearch.files_count,
-          \ a:esearch.highlights_enabled])
+    let original_cwd = getcwd()
+    exe 'lcd ' . a:esearch.request.cwd
+    try
+      let [files_count, contexts, ctx_ids_map, line_numbers_map, context_by_name] =
+            \ luaeval('esearch_out_win_render_nvim(_A[1], _A[2], _A[3], _A[4], _A[5], _A[6])',
+            \ [a:data[a:from : a:to],
+            \ get(a:esearch.paths, 0, ''),
+            \ a:esearch.contexts[-1],
+            \ a:esearch.files_count,
+            \ a:esearch.highlights_enabled])
+    finally
+      exe 'lcd ' . original_cwd
+    endtry
 
     let a:esearch.files_count = files_count
     call extend(a:esearch.contexts, contexts[1:])
@@ -53,11 +58,16 @@ if g:esearch#has#nvim_lua
   endfu
 else
   fu! esearch#out#win#render#lua#do(bufnr, data, from, to, esearch) abort
-  let a:esearch['files_count'] = luaeval('esearch_out_win_render_vim(_A[0], _A[1], _A[2], _A[3], _A[4], _A[5])',
-          \ [a:data[a:from : a:to],
-          \ get(b:esearch.paths, 0, ''),
-          \ a:esearch.lua_cwd_prefix,
-          \ a:esearch])
+    let original_cwd = getcwd()
+    exe 'lcd ' . a:esearch.request.cwd
+    try
+      let a:esearch['files_count'] = luaeval('esearch_out_win_render_vim(_A[0], _A[1], _A[2], _A[3], _A[4])',
+            \ [a:data[a:from : a:to],
+            \ get(b:esearch.paths, 0, ''),
+            \ a:esearch])
+    finally
+      exe 'lcd ' . original_cwd
+    endtry
   endfu
 endif
 
@@ -65,8 +75,8 @@ if g:esearch#has#nvim_lua
 lua << EOF
 filereadable_cache = {}
 
-function esearch_out_win_render_nvim(data, path, cwd_prefix, last_context, files_count, highlights_enabled)
-  local parsed = parse_lines(data, cwd_prefix)
+function esearch_out_win_render_nvim(data, path, last_context, files_count, highlights_enabled)
+  local parsed = parse_lines(data)
   local contexts = {last_context}
   local line_numbers_map = {}
   local ctx_ids_map = {}
@@ -182,8 +192,8 @@ EOF
 else
 
 lua << EOF
-function esearch_out_win_render_vim(data, path, cwd_prefix, esearch)
-  local parsed           = parse_lines(data, cwd_prefix)
+function esearch_out_win_render_vim(data, path, esearch)
+  local parsed           = parse_lines(data)
   local contexts         = esearch['contexts']
   local line_numbers_map = esearch['line_numbers_map']
   local ctx_ids_map      = esearch['ctx_ids_map']

--- a/autoload/esearch/out/win/render/lua.vim
+++ b/autoload/esearch/out/win/render/lua.vim
@@ -21,8 +21,7 @@ endif
 
 if g:esearch#has#nvim_lua
   fu! esearch#out#win#render#lua#do(bufnr, data, from, to, esearch) abort
-    let original_cwd = getcwd()
-    exe 'lcd ' . a:esearch.request.cwd
+    let original_cwd = esearch#util#lcd(a:esearch.cwd)
     try
       let [files_count, contexts, ctx_ids_map, line_numbers_map, context_by_name] =
             \ luaeval('esearch_out_win_render_nvim(_A[1], _A[2], _A[3], _A[4], _A[5], _A[6])',
@@ -32,7 +31,7 @@ if g:esearch#has#nvim_lua
             \ a:esearch.files_count,
             \ a:esearch.highlights_enabled])
     finally
-      exe 'lcd ' . original_cwd
+      call original_cwd.restore()
     endtry
 
     let a:esearch.files_count = files_count
@@ -58,15 +57,14 @@ if g:esearch#has#nvim_lua
   endfu
 else
   fu! esearch#out#win#render#lua#do(bufnr, data, from, to, esearch) abort
-    let original_cwd = getcwd()
-    exe 'lcd ' . a:esearch.request.cwd
+    let original_cwd = esearch#util#lcd(a:esearch.cwd)
     try
       let a:esearch['files_count'] = luaeval('esearch_out_win_render_vim(_A[0], _A[1], _A[2], _A[3], _A[4])',
             \ [a:data[a:from : a:to],
             \ get(b:esearch.paths, 0, ''),
             \ a:esearch])
     finally
-      exe 'lcd ' . original_cwd
+      call original_cwd.restore()
     endtry
   endfu
 endif

--- a/autoload/esearch/out/win/render/viml.vim
+++ b/autoload/esearch/out/win/render/viml.vim
@@ -1,66 +1,71 @@
 let s:linenr_format = ' %3d %s'
 
 fu! esearch#out#win#render#viml#do(bufnr, data, from, to, esearch) abort
-  let parsed = a:esearch.parse(a:data, a:from, a:to)
+  let original_cwd = getcwd()
+  exe 'lcd ' . a:esearch.request.cwd
+  try
+    let line = line('$') + 1
+    let i = 0
+    let limit = len(parsed)
+    let lines = []
+    let parsed = a:esearch.parse(a:data, a:from, a:to)
 
-  let line = line('$') + 1
-  let i = 0
-  let limit = len(parsed)
-  let lines = []
+    while i < limit
+      let filename = parsed[i].filename
 
-  while i < limit
-    let filename = parsed[i].filename
-
-    if g:esearch_win_ellipsize_results
-      let text = esearch#util#ellipsize(
-            \ parsed[i].text,
-            \ parsed[i].col,
-            \ a:esearch.context_width.left,
-            \ a:esearch.context_width.right,
-            \ g:esearch#util#ellipsis)
-    else
-
-      let text = parsed[i].text
-    endif
-
-    if filename !=# a:esearch.contexts[-1].filename
-      let a:esearch.contexts[-1].end = line
-
-      if a:esearch.highlights_enabled &&
-            \ a:esearch.contexts[-1].id > g:esearch_win_disable_context_highlights_on_files_count
-        call esearch#out#win#unload_highlights()
-      end
-
-      call add(lines, '')
-      call add(a:esearch.ctx_ids_map, a:esearch.contexts[-1].id)
-      call add(a:esearch.line_numbers_map, 0)
-      let line += 1
-
-      call add(lines, fnameescape(filename))
-      call esearch#out#win#add_context(a:esearch.contexts, filename, line)
-      let a:esearch.context_by_name[filename] = a:esearch.contexts[-1]
-      call add(a:esearch.ctx_ids_map, a:esearch.contexts[-1].id)
-      call add(a:esearch.line_numbers_map, 0)
-      let a:esearch.files_count += 1
-      let line += 1
-      let a:esearch.contexts[-1].filename = filename
-    endif
-
-    if len(text) > g:unload_context_syntax_on_line_length
-      if len(text) > g:unload_global_syntax_on_line_length
-        call esearch#out#win#_blocking_unload_syntaxes(a:esearch)
+      if g:esearch_win_ellipsize_results
+        let text = esearch#util#ellipsize(
+              \ parsed[i].text,
+              \ parsed[i].col,
+              \ a:esearch.context_width.left,
+              \ a:esearch.context_width.right,
+              \ g:esearch#util#ellipsis)
       else
-        let a:esearch.contexts[-1].syntax_loaded = -1
-      end
-    end
 
-    call add(lines, printf(s:linenr_format, parsed[i].lnum, text))
-    call add(a:esearch.line_numbers_map, parsed[i].lnum)
-    call add(a:esearch.ctx_ids_map, a:esearch.contexts[-1].id)
-    let a:esearch.contexts[-1].lines[parsed[i].lnum] = parsed[i].text
-    let line += 1
-    let i    += 1
-  endwhile
+        let text = parsed[i].text
+      endif
+
+      if filename !=# a:esearch.contexts[-1].filename
+        let a:esearch.contexts[-1].end = line
+
+        if a:esearch.highlights_enabled &&
+              \ a:esearch.contexts[-1].id > g:esearch_win_disable_context_highlights_on_files_count
+          call esearch#out#win#unload_highlights()
+        end
+
+        call add(lines, '')
+        call add(a:esearch.ctx_ids_map, a:esearch.contexts[-1].id)
+        call add(a:esearch.line_numbers_map, 0)
+        let line += 1
+
+        call add(lines, fnameescape(filename))
+        call esearch#out#win#add_context(a:esearch.contexts, filename, line)
+        let a:esearch.context_by_name[filename] = a:esearch.contexts[-1]
+        call add(a:esearch.ctx_ids_map, a:esearch.contexts[-1].id)
+        call add(a:esearch.line_numbers_map, 0)
+        let a:esearch.files_count += 1
+        let line += 1
+        let a:esearch.contexts[-1].filename = filename
+      endif
+
+      if len(text) > g:unload_context_syntax_on_line_length
+        if len(text) > g:unload_global_syntax_on_line_length
+          call esearch#out#win#_blocking_unload_syntaxes(a:esearch)
+        else
+          let a:esearch.contexts[-1].syntax_loaded = -1
+        end
+      end
+
+      call add(lines, printf(s:linenr_format, parsed[i].lnum, text))
+      call add(a:esearch.line_numbers_map, parsed[i].lnum)
+      call add(a:esearch.ctx_ids_map, a:esearch.contexts[-1].id)
+      let a:esearch.contexts[-1].lines[parsed[i].lnum] = parsed[i].text
+      let line += 1
+      let i    += 1
+    endwhile
+  finally
+    exe 'lcd ' . original_cwd
+  endtry
 
   call esearch#util#append_lines(lines)
 endfu

--- a/autoload/esearch/out/win/render/viml.vim
+++ b/autoload/esearch/out/win/render/viml.vim
@@ -1,8 +1,7 @@
 let s:linenr_format = ' %3d %s'
 
 fu! esearch#out#win#render#viml#do(bufnr, data, from, to, esearch) abort
-  let original_cwd = getcwd()
-  exe 'lcd ' . a:esearch.request.cwd
+  let original_cwd = esearch#util#lcd(a:esearch.cwd)
   try
     let parsed = a:esearch.parse(a:data, a:from, a:to)
     let line = line('$') + 1
@@ -64,7 +63,7 @@ fu! esearch#out#win#render#viml#do(bufnr, data, from, to, esearch) abort
       let i    += 1
     endwhile
   finally
-    exe 'lcd ' . original_cwd
+    call original_cwd.restore()
   endtry
 
   call esearch#util#append_lines(lines)

--- a/autoload/esearch/out/win/render/viml.vim
+++ b/autoload/esearch/out/win/render/viml.vim
@@ -4,11 +4,11 @@ fu! esearch#out#win#render#viml#do(bufnr, data, from, to, esearch) abort
   let original_cwd = getcwd()
   exe 'lcd ' . a:esearch.request.cwd
   try
+    let parsed = a:esearch.parse(a:data, a:from, a:to)
     let line = line('$') + 1
     let i = 0
     let limit = len(parsed)
     let lines = []
-    let parsed = a:esearch.parse(a:data, a:from, a:to)
 
     while i < limit
       let filename = parsed[i].filename

--- a/autoload/esearch/util.vim
+++ b/autoload/esearch/util.vim
@@ -660,3 +660,26 @@ fu! esearch#util#silence_swap_prompt() abort
   " F - don't echo that a:filename is edited
   return esearch#let#restorable({'&shortmess': 'AF'})
 endfu
+
+fu! esearch#util#lcd(path) abort
+  return s:DirectoryGuard.store(a:path)
+endfu
+
+let s:DirectoryGuard = {'cwd': ''}
+
+fu! s:DirectoryGuard.store(path) abort dict
+  let instance = copy(self)
+
+  if !empty(a:path)
+    let instance.cwd = getcwd()
+    exe 'lcd ' . a:path
+  endif
+
+  return instance
+endfu
+
+fu! s:DirectoryGuard.restore() abort dict
+  if !empty(self.cwd)
+    exe 'lcd ' . self.cwd
+  endif
+endfu

--- a/spec/known_issues.rb
+++ b/spec/known_issues.rb
@@ -60,6 +60,7 @@ KnownIssues.allow_tests_to_fail_matching_by_metadata do
 
   # Ack cannot work with files named ~
   pending! 'searching in a file with name "~"', /MissingEntry/, adapter: :ack
+  pending! 'searching in a file with name "-"', /MissingEntry/, adapter: :ack
 
   # Can be fixed by storing data as a single string instead of list of lines.
   # Can reduce freezes on stdout callbacks, but seems too hard to implement for

--- a/spec/known_issues.rb
+++ b/spec/known_issues.rb
@@ -72,24 +72,4 @@ KnownIssues.allow_tests_to_fail_matching_by_metadata do
 
   # vimproc doesn't handle LF as job control does
   pending! 'searching in a file with name "a\\r"', /MissingEntry/, backend: :vimproc
-
-  # getqflist() parser is a fast builtin, but it looks too buggy. Although it's
-  # not the usual case, it affects reliability
-  pending! 'searching in a file with name "a:1:b/a:1"', /MissingEntry/, parse: :getqflist
-  pending! 'searching in a file with name "a:b-1/a-b"', /MissingEntry/, parse: :getqflist
-  pending! 'searching in a file with name "\"a\":1:b"', /MissingEntry/, parse: :getqflist
-  pending! 'searching in a file with name "Σ:1:2-"',    /MissingEntry/, parse: :getqflist
-  pending! 'searching in a file with name "Σ:1:2:"',    /MissingEntry/, parse: :getqflist
-  pending! 'searching in a file with name "a:1:2:"',    /MissingEntry/, parse: :getqflist
-  pending! 'searching in a file with name "a:1:2-"',    /MissingEntry/, parse: :getqflist
-  pending! 'searching in a file with name "a:1"',       /MissingEntry/, parse: :getqflist
-  pending! 'searching in a file with name "a:1:"',      /MissingEntry/, parse: :getqflist
-  pending! 'searching in a file with name "a:1:2"',     /MissingEntry/, parse: :getqflist
-  pending! 'searching in a file with name "Σ:1:b/Σ:1"', /MissingEntry/, parse: :getqflist
-  # Leading ws are unfairly consumed
-  pending! 'searching in a file with name " a"', /MissingEntry/, parse: :getqflist
-  pending! 'searching in a file with name " 1 a b"', /MissingEntry/, parse: :getqflist
-  # Documented feature of getqflist - to expand tilde and some other special
-  # chars. See :h errorformat
-  pending! 'searching in a file with name "~"', /MissingEntry/, parse: :getqflist
 end

--- a/spec/plugin/backend_spec.rb
+++ b/spec/plugin/backend_spec.rb
@@ -20,7 +20,6 @@ describe 'esearch#backend', :backend do
       let(:column) { 3..4 }
       let(:expected_file) { file("_\n__#{search_string}_", path) }
       let(:test_directory) { directory([expected_file]).persist! }
-      let(:escaped_path) { editor.escape_filename(path) }
 
       before do
         esearch.configuration.submit!
@@ -38,10 +37,10 @@ describe 'esearch#backend', :backend do
             .to  have_search_started
             .and have_search_finished
             .and have_not_reported_errors
-            .and have_search_highlight(escaped_path, line, column)
-            .and have_filename_highlight(escaped_path)
-            .and have_outputted_result_from_file_in_line(escaped_path, line)
-            .and have_outputted_result_with_right_position_inside_file(escaped_path, line, column.begin)
+            .and have_search_highlight(path, line, column)
+            .and have_filename_highlight(path)
+            .and have_outputted_result_from_file_in_line(path, line)
+            .and have_outputted_result_with_right_position_inside_file(path, line, column.begin)
         end
       end
     end

--- a/spec/plugin/backend_spec.rb
+++ b/spec/plugin/backend_spec.rb
@@ -346,7 +346,6 @@ describe 'esearch#backend', :backend do
     before do
       editor.command <<~VIML
         let g:esearch_out_win_render_using_lua = 0
-        let g:esearch_out_win_parse_using_getqflist = 0
       VIML
     end
 
@@ -358,7 +357,6 @@ describe 'esearch#backend', :backend do
     before(:context) do
       editor.command <<~VIML
         let g:esearch_out_win_render_using_lua = 0
-        let g:esearch_out_win_parse_using_getqflist = 0
         let g:esearch#backend#vimproc#updatetime = 30
         let g:esearch#backend#vimproc#read_timeout = 30
         let g:esearch_win_update_using_timer = 0
@@ -399,19 +397,6 @@ describe 'esearch#backend', :backend do
         before do
           editor.command <<~VIML
             let g:esearch_out_win_render_using_lua = 0
-            let g:esearch_out_win_parse_using_getqflist = 0
-          VIML
-        end
-
-        include_context 'a backend', 'vim8'
-        include_context 'a backend 2', 'vim8'
-      end
-
-      context 'when parsing with #getqflist', parse: :getqflist do
-        before do
-          editor.command <<~VIML
-            let g:esearch_out_win_render_using_lua = 0
-            let g:esearch_out_win_parse_using_getqflist = 1
           VIML
         end
 

--- a/spec/support/api/esearch/window.rb
+++ b/spec/support/api/esearch/window.rb
@@ -125,7 +125,8 @@ class API::ESearch::Window
 
   def find_entry(relative_path, line_in_file)
     found = parser.entries.find do |entry|
-      entry.relative_path == relative_path && entry.line_in_file == line_in_file
+      Pathname(entry.relative_path).cleanpath == Pathname(relative_path).cleanpath &&
+        entry.line_in_file == line_in_file
     end
 
     found || MissingEntry.new(relative_path, line_in_file)

--- a/spec/support/api/esearch/window.rb
+++ b/spec/support/api/esearch/window.rb
@@ -39,8 +39,11 @@ class API::ESearch::Window
   def has_filename_highlight?(relative_path)
     return true if Debug.neovim?
 
-    filename = editor.escape_regexp(editor.escape_filename(relative_path))
-    editor.syntax_aliases_at([filename]) ==
+    # Both a valid. The only difference is that vim escapes > and + only when
+    # they are leading
+    filename_variations = [editor.escape_regexp(editor.escape_filename(relative_path)),
+                           editor.escape_regexp(editor.escape_filename('./' + relative_path))]
+    editor.syntax_aliases_at([filename_variations.join('\|')]) ==
       [%w[esearchFilename Directory]]
   end
 
@@ -128,8 +131,8 @@ class API::ESearch::Window
     found = parser.entries.find do |entry|
       entry_path = Pathname(entry.relative_path).cleanpath
 
-      # Both a valid. The only difference is that vim escapes only several
-      # characters in paths when they are leading like > and +
+      # Both a valid. The only difference is that vim escapes > and + only when
+      # they are leading
       path_variations = [Pathname(editor.escape_filename('./' + relative_path)).cleanpath,
                          Pathname(editor.escape_filename(relative_path)).cleanpath]
 

--- a/spec/support/helpers/modifiable.rb
+++ b/spec/support/helpers/modifiable.rb
@@ -28,7 +28,7 @@ module Helpers::Modifiable
 
     def entries
       line_numbers.map do |line_number|
-        esearch.output.find_entry(editor.escape_filename(name), line_number)
+        esearch.output.find_entry(name, line_number)
       rescue API::ESearch::Window::MissingEntryError
         nil
       end

--- a/spec/support/helpers/modifiable/columnwise.rb
+++ b/spec/support/helpers/modifiable/columnwise.rb
@@ -65,7 +65,7 @@ module Helpers::Modifiable::Columnwise
     end
 
     def parsed_entry
-      esearch.output.find_entry(editor.escape_filename(relative_path), line_in_file)
+      esearch.output.find_entry(relative_path, line_in_file)
     end
   end
 


### PR DESCRIPTION
- Less frezees on consuming stdout by forcing them to strip cwd (happens when search utils fetch search results from their cache).
- Drop getqflines parser support. Reasons: 1. simplify the development, 2. less reliable when paths contain separators or start with whitespaces, 3. slower than lua parser.
- Slight performance improvement: around 10-20% percent for consume + parse + render in total.