### PR TITLE
Release 0.2.3 Fix keymaps setting deprecations

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,2 +1,3 @@
 disable=SC1090 # Can't follow non-constant source. Use a directive to specify location.
 disable=SC2039 # In POSIX sh, something is undefined
+disable=SC3043 # In POSIX sh, 'local' is undefined

--- a/autoload/esearch/out/win.vim
+++ b/autoload/esearch/out/win.vim
@@ -134,8 +134,8 @@ fu! esearch#out#win#map(lhs, rhs) abort
   let g:esearch = get(g:, 'esearch', {})
   let g:esearch = extend(g:esearch, {'win_map': []}, 'keep')
   let g:esearch = extend(g:esearch, {'pending_deprecations': []}, 'keep')
-  let g:esearch.pending_deprecations += ['esearch#out#win#map, see :help g:esearch.win_map']
-  let g:esearch.win_map += [{'lhs': a:lhs, 'rhs': get(g:esearch#out#win#legacy_mappings, a:rhs, a:rhs), 'mode': 'n'}]
+  let g:esearch.pending_deprecations += ['esearch#out#win#map(), see :help g:esearch.win_map']
+  let g:esearch.win_map += [['n', a:lhs, get(g:esearch#out#win#legacy_mappings, a:rhs, a:rhs)]]
 endfu
 
 fu! s:init_mappings() abort

--- a/plugin/esearch.vim
+++ b/plugin/esearch.vim
@@ -1,7 +1,7 @@
 if exists('g:loaded_esearch')
   finish
 endif
-let g:loaded_esearch = '0.2.2'
+let g:loaded_esearch = '0.2.3'
 
 if !hasmapto('<Plug>(esearch)') && !hasmapto('<Plug>(operator-esearch-prefill)') && get(get(g:, 'esearch', {}), 'default_mappings', 1)
   nmap <leader>ff <Plug>(esearch)


### PR DESCRIPTION
* Fix deprecation warnings for keymaps added using `esearch#out#win#map()`